### PR TITLE
Feat/issue #57

### DIFF
--- a/src/main/kotlin/com/knu/mockin/controller/AccountController.kt
+++ b/src/main/kotlin/com/knu/mockin/controller/AccountController.kt
@@ -48,20 +48,38 @@ class AccountController(
         return ResponseEntity.ok("등록 완료")
     }
 
-    @PostMapping("/approval-key")
-    suspend fun getApprovalKey(
+    @PostMapping("/mock-approval-key")
+    suspend fun getMockApprovalKey(
         @RequestBody accountRequestDto: AccountRequestDto
     ): ResponseEntity<ApprovalKeyResponseDto> {
-        val result = accountService.getApprovalKey(accountRequestDto)
+        val result = accountService.getMockApprovalKey(accountRequestDto)
 
         return ResponseEntity.ok(result)
     }
 
-    @PostMapping("/token")
-    suspend fun getAccessToken(
+    @PostMapping("/real-approval-key")
+    suspend fun getRealApprovalKey(
+            @RequestBody accountRequestDto: AccountRequestDto
+    ): ResponseEntity<ApprovalKeyResponseDto> {
+        val result = accountService.getRealApprovalKey(accountRequestDto)
+
+        return ResponseEntity.ok(result)
+    }
+
+    @PostMapping("/mock-token")
+    suspend fun getMockAccessToken(
         @RequestBody accountRequestDto: AccountRequestDto
     ): ResponseEntity<AccessTokenAPIResponseDto> {
-        val result = accountService.getAccessToken(accountRequestDto)
+        val result = accountService.getMockAccessToken(accountRequestDto)
+
+        return ResponseEntity.ok(result)
+    }
+
+    @PostMapping("/real-token")
+    suspend fun getRealMockAccessToken(
+            @RequestBody accountRequestDto: AccountRequestDto
+    ): ResponseEntity<AccessTokenAPIResponseDto> {
+        val result = accountService.getRealAccessToken(accountRequestDto)
 
         return ResponseEntity.ok(result)
     }

--- a/src/test/kotlin/com/knu/mockin/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/AccountControllerTest.kt
@@ -55,7 +55,7 @@ class AccountControllerTest(
             appKey = "appKey",
             secretKey = "appSecret")
         val expectedDto = ApprovalKeyResponseDto("test")
-        coEvery { accountService.getApprovalKey(accountDto) } returns expectedDto
+        coEvery { accountService.getMockApprovalKey(accountDto) } returns expectedDto
 
         val result = webTestClient.post().uri("/account/approval-key").accept(APPLICATION_JSON)
             .bodyValue(accountDto)

--- a/src/test/kotlin/com/knu/mockin/service/accountservice/AccountServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/accountservice/AccountServiceTest.kt
@@ -1,6 +1,7 @@
 package com.knu.mockin.service.accountservice
 
 import com.knu.mockin.kisclient.KISOauth2Client
+import com.knu.mockin.kisclient.KISOauth2RealClient
 import com.knu.mockin.model.dto.kisrequest.oauth.KISApprovalRequestDto
 import com.knu.mockin.model.dto.kisrequest.oauth.KISTokenRequestDto
 import com.knu.mockin.model.dto.request.account.AccountRequestDto
@@ -22,11 +23,13 @@ import reactor.core.publisher.Mono
 
 class AccountServiceTest: BehaviorSpec({
     val kisOauth2Client: KISOauth2Client = mockk<KISOauth2Client>()
+    val kisOauth2RealClient: KISOauth2RealClient = mockk<KISOauth2RealClient>()
     val mockKeyRepository: MockKeyRepository = mockk()
     val userRepository: UserRepository = mockk()
     val realKeyRepository: RealKeyRepository = mockk()
     val accountService = AccountService(
         kisOauth2Client = kisOauth2Client,
+        kisOauth2RealClient = kisOauth2RealClient,
         mockKeyRepository = mockKeyRepository,
         realKeyRepository = realKeyRepository,
         userRepository = userRepository
@@ -46,7 +49,7 @@ class AccountServiceTest: BehaviorSpec({
         every { kisOauth2Client.postApproval(requestDto) } returns Mono.just(expectedDto)
         every { mockKeyRepository.findById("test")} returns Mono.just(mockKey)
         When("서비스 계층에 요청을 보내면:"){
-            val result = accountService.getApprovalKey(accountRequestDto)
+            val result = accountService.getMockApprovalKey(accountRequestDto)
 
             Then("키가 반환된다"){
                 result shouldBe expectedDto
@@ -72,7 +75,7 @@ class AccountServiceTest: BehaviorSpec({
         every { RedisUtil.saveToken(accountRequestDto.email, expectedDto.accessToken) } returns Unit
 
         When("서비스 계층에 요청을 보내면:"){
-            val result = accountService.getAccessToken(accountRequestDto)
+            val result = accountService.getMockAccessToken(accountRequestDto)
 
             Then("토큰이 반환된다"){
                 result shouldBe expectedDto


### PR DESCRIPTION
## **PR**

### 작업 내용
- 실전 계좌용 웹소켓키, 토큰 발급 Controller, Service 추가
---
### 참고 사항
원래 호출 주소 앞에
모의계좌: mock- 추가
실전계좌: real- 추가
postman 등록해두었습니다!
---
### ✏ Git Close
#57 
