### PR TITLE
Refactor/issue #86

### DIFF
--- a/src/main/kotlin/com/knu/mockin/aspect/ErrorAspect.kt
+++ b/src/main/kotlin/com/knu/mockin/aspect/ErrorAspect.kt
@@ -2,7 +2,6 @@ package com.knu.mockin.aspect
 
 import com.knu.mockin.exeption.CustomException
 import com.knu.mockin.exeption.ErrorCode
-import com.knu.mockin.util.ExtensionUtil.returnWhenSuccess
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
@@ -10,6 +9,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
+import kotlin.reflect.full.memberProperties
 
 @Aspect
 @Component
@@ -40,5 +40,17 @@ class ErrorAspect {
             Mono.error(CustomException(ErrorCode.INTERNAL_SERVER_ERROR))
         }
     }
+    private fun <T> Mono<T>.returnWhenSuccess():Mono<T> {
+        return this.flatMap { instance ->
+            val properties = instance!!::class.memberProperties
+            val successFailureCode = properties.find { it.name == "successFailureStatus" }?.call(instance)
+            val message = properties.find { it.name == "responseMessage" }?.call(instance)
 
+            if (successFailureCode != null && successFailureCode != "0") {
+                return@flatMap Mono.error(CustomException(ErrorCode.KIS_API_FAILED, message.toString()))
+            }
+
+            Mono.just(instance)
+        }
+    }
 }

--- a/src/main/kotlin/com/knu/mockin/aspect/ErrorAspect.kt
+++ b/src/main/kotlin/com/knu/mockin/aspect/ErrorAspect.kt
@@ -14,8 +14,6 @@ import kotlin.reflect.full.memberProperties
 @Aspect
 @Component
 class ErrorAspect {
-    private val log = LoggerFactory.getLogger(ErrorAspect::class.java)
-
     @Around("execution(* com.knu.mockin.kisclient..*(..))")
     fun handleKISWebClientException(joinPoint: ProceedingJoinPoint): Any {
         return try {

--- a/src/main/kotlin/com/knu/mockin/exeption/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/knu/mockin/exeption/GlobalExceptionHandler.kt
@@ -1,13 +1,17 @@
 package com.knu.mockin.exeption
 
+import com.knu.mockin.logging.utils.LogUtil
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 
 @ControllerAdvice
 class GlobalExceptionHandler {
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
     @ExceptionHandler(CustomException::class)
     fun handleCustomException(exception: CustomException): ResponseEntity<*> {
+        log.error("{}", LogUtil.toJson(exception))
         return ResponseEntity.status(exception.errorCode.status)
             .body(ExceptionDto(exception.result, exception.errorCode, exception.message))
     }

--- a/src/main/kotlin/com/knu/mockin/exeption/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/knu/mockin/exeption/GlobalExceptionHandler.kt
@@ -1,17 +1,13 @@
 package com.knu.mockin.exeption
 
-import com.knu.mockin.logging.utils.LogUtil
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 
 @ControllerAdvice
 class GlobalExceptionHandler {
-    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
     @ExceptionHandler(CustomException::class)
     fun handleCustomException(exception: CustomException): ResponseEntity<*> {
-        log.error("{}", LogUtil.toJson(exception))
         return ResponseEntity.status(exception.errorCode.status)
             .body(ExceptionDto(exception.result, exception.errorCode, exception.message))
     }

--- a/src/main/kotlin/com/knu/mockin/util/ExtensionUtil.kt
+++ b/src/main/kotlin/com/knu/mockin/util/ExtensionUtil.kt
@@ -3,24 +3,9 @@ package com.knu.mockin.util
 import com.knu.mockin.exeption.CustomException
 import com.knu.mockin.exeption.ErrorCode
 import reactor.core.publisher.Mono
-import kotlin.reflect.full.memberProperties
 
 object ExtensionUtil {
     fun <T> Mono<T>.orThrow(errorCode: ErrorCode): Mono<T> {
         return this.switchIfEmpty(Mono.error(CustomException(errorCode)))
-    }
-
-    fun <T> Mono<T>.returnWhenSuccess():Mono<T> {
-        return this.flatMap { instance ->
-            val properties = instance!!::class.memberProperties
-            val successFailureCode = properties.find { it.name == "successFailureStatus" }?.call(instance)
-            val message = properties.find { it.name == "responseMessage" }?.call(instance)
-
-            if (successFailureCode != null && successFailureCode != "0") {
-                return@flatMap Mono.error(CustomException(ErrorCode.KIS_API_FAILED, message.toString()))
-            }
-
-            Mono.just(instance)
-        }
     }
 }


### PR DESCRIPTION
## **PR**

### 작업 내용

- KIS API 예외 처리 함수 returnWhenSuccess를 Aspect 안으로 이동
---
### 참고 사항

로깅과 에러의 책임을 분리하려고 했으나, 알 수 없는 오류로 불가능
해당 오류는 노션/트러블 슈팅/Aspect Afterthrowing 안됨 참고
당장 책임 분리는 보류하기로 함.

---
### ✏ Git Close
#86 