### PR TITLE
Feat/issue #98

### DIFF
--- a/src/docs/asciidoc/basic.adoc
+++ b/src/docs/asciidoc/basic.adoc
@@ -13,6 +13,7 @@
 * <<price-detail, 현재가상세>>
 * <<item-chart-price, 주식분봉조회>>
 * <<index-chart-price, 지수분봉조회>>
+* <<news-title, 해외뉴스종합>>
 
 [#current]
 == 현재체결가
@@ -140,4 +141,17 @@ include::{snippets}/basic/index-chart-price/http-response.adoc[]
 include::{snippets}/basic/index-chart-price/response-fields.adoc[]
 
 
+[#news-title]
+== 해외뉴스종합
 
+=== Request
+include::{snippets}/basic/news-title/http-request.adoc[]
+
+=== Request-Field
+include::{snippets}/basic/news-title/query-parameters.adoc[]
+
+=== Response
+include::{snippets}/basic/news-title/http-response.adoc[]
+
+=== Response-Field
+include::{snippets}/basic/news-title/response-fields.adoc[]

--- a/src/main/kotlin/com/knu/mockin/controller/BasicRealController.kt
+++ b/src/main/kotlin/com/knu/mockin/controller/BasicRealController.kt
@@ -1,13 +1,7 @@
 package com.knu.mockin.controller
 
-import com.knu.mockin.model.dto.kisresponse.basic.KISCountriesHolidayResponseDto
-import com.knu.mockin.model.dto.kisresponse.basic.KISIndexChartPriceResponseDto
-import com.knu.mockin.model.dto.kisresponse.basic.KISItemChartPriceResponseDto
-import com.knu.mockin.model.dto.kisresponse.basic.KISPriceDetailResponseDto
-import com.knu.mockin.model.dto.request.basic.CountriesHolidayRequestParameterDto
-import com.knu.mockin.model.dto.request.basic.IndexChartPriceRequestParameterDto
-import com.knu.mockin.model.dto.request.basic.ItemChartPriceRequestParameterDto
-import com.knu.mockin.model.dto.request.basic.PriceDetailRequestParameterDto
+import com.knu.mockin.model.dto.kisresponse.basic.*
+import com.knu.mockin.model.dto.request.basic.*
 import com.knu.mockin.service.BasicRealService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -57,5 +51,12 @@ class BasicRealController (
         return ResponseEntity.ok(result)
     }
 
+    @GetMapping("/news-title")
+    suspend fun getNewsTitle(
+        @ModelAttribute newsTitleRequestParameterDto: NewsTitleRequestParameterDto
+    ): ResponseEntity<KISNewsTitleResponseDto> {
+        val result = basicRealService.getNewsTitle(newsTitleRequestParameterDto)
 
+        return ResponseEntity.ok(result)
+    }
 }

--- a/src/main/kotlin/com/knu/mockin/kisclient/KISBasicRealClient.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISBasicRealClient.kt
@@ -1,14 +1,8 @@
 package com.knu.mockin.kisclient
 
 import com.knu.mockin.model.dto.kisheader.request.KISOverSeaRequestHeaderDto
-import com.knu.mockin.model.dto.kisrequest.basic.KISCountriesHolidayRequestParameterDto
-import com.knu.mockin.model.dto.kisrequest.basic.KISIndexChartPriceRequestParameterDto
-import com.knu.mockin.model.dto.kisrequest.basic.KISItemChartPriceRequestParameterDto
-import com.knu.mockin.model.dto.kisrequest.basic.KISPriceDetailRequestParameterDto
-import com.knu.mockin.model.dto.kisresponse.basic.KISCountriesHolidayResponseDto
-import com.knu.mockin.model.dto.kisresponse.basic.KISIndexChartPriceResponseDto
-import com.knu.mockin.model.dto.kisresponse.basic.KISItemChartPriceResponseDto
-import com.knu.mockin.model.dto.kisresponse.basic.KISPriceDetailResponseDto
+import com.knu.mockin.model.dto.kisrequest.basic.*
+import com.knu.mockin.model.dto.kisresponse.basic.*
 import com.knu.mockin.util.HttpUtils
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -69,4 +63,15 @@ class KISBasicRealClient (
                 .bodyToMono(KISIndexChartPriceResponseDto::class.java)
     }
 
+    fun getNewsTitle(
+        header: KISOverSeaRequestHeaderDto,
+        requestParameter: KISNewsTitleRequestParameterDto
+    ): Mono<KISNewsTitleResponseDto> {
+        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/news-title", requestParameter)
+        return webClientReal.get()
+            .uri(targetUri)
+            .headers { HttpUtils.addHeaders(it, header) }
+            .retrieve()
+            .bodyToMono(KISNewsTitleResponseDto::class.java)
+    }
 }

--- a/src/main/kotlin/com/knu/mockin/model/dto/kisrequest/basic/KISNewsTitleRequestParameterDto.kt
+++ b/src/main/kotlin/com/knu/mockin/model/dto/kisrequest/basic/KISNewsTitleRequestParameterDto.kt
@@ -1,0 +1,14 @@
+package com.knu.mockin.model.dto.kisrequest.basic
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KISNewsTitleRequestParameterDto(
+    @JsonProperty("INFO_GB") val newsCategory: String = "",         // 뉴스구분
+    @JsonProperty("CLASS_CD") val categoryCode: String = "",        // 중분류
+    @JsonProperty("NATION_CD") val countryCode: String = "",        // 국가코드
+    @JsonProperty("EXCHANGE_CD") val exchangeCode: String = "",     // 거래소코드
+    @JsonProperty("SYMB") val stockCode: String = "",               // 종목코드
+    @JsonProperty("DATA_DT") val queryDate: String = "",            // 조회일자
+    @JsonProperty("DATA_TM") val queryTime: String = "",            // 조회시간
+    @JsonProperty("CTS") val nextKey: String = ""                   // 다음키
+)

--- a/src/main/kotlin/com/knu/mockin/model/dto/kisresponse/basic/KISNewsTitleResponseDto.kt
+++ b/src/main/kotlin/com/knu/mockin/model/dto/kisresponse/basic/KISNewsTitleResponseDto.kt
@@ -1,0 +1,25 @@
+package com.knu.mockin.model.dto.kisresponse.basic
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KISNewsTitleResponseDto(
+    @JsonProperty("rt_cd") val successStatus: String, // 성공 실패 여부
+    @JsonProperty("msg_cd") val responseCode: String, // 응답코드
+    @JsonProperty("msg1") val responseMessage: String, // 응답메세지
+    @JsonProperty("outblock1") val details: List<NewsDetail> // 응답상세
+)
+
+data class NewsDetail(
+    @JsonProperty("info_gb") val newsCategory: String,      // 뉴스구분
+    @JsonProperty("news_key") val newsKey: String,          // 뉴스키
+    @JsonProperty("data_dt") val queryDate: String,         // 조회일자
+    @JsonProperty("data_tm") val queryTime: String,         // 조회시간
+    @JsonProperty("class_cd") val categoryCode: String,     // 중분류
+    @JsonProperty("class_name") val categoryName: String,   // 중분류명
+    @JsonProperty("source") val source: String,             // 자료원
+    @JsonProperty("nation_cd") val countryCode: String,     // 국가코드
+    @JsonProperty("exchange_cd") val exchangeCode: String,  // 거래소코드
+    @JsonProperty("symb") val stockCode: String,            // 종목코드
+    @JsonProperty("symb_name") val stockName: String,       // 종목명
+    @JsonProperty("title") val title: String                // 제목
+)

--- a/src/main/kotlin/com/knu/mockin/model/dto/request/basic/NewsTitleRequestParameterDto.kt
+++ b/src/main/kotlin/com/knu/mockin/model/dto/request/basic/NewsTitleRequestParameterDto.kt
@@ -1,0 +1,7 @@
+package com.knu.mockin.model.dto.request.basic
+
+data class NewsTitleRequestParameterDto(
+    val queryDate: String = "",            // 조회일자
+    val queryTime: String = "",            // 조회시간
+    val email: String = ""
+)

--- a/src/main/kotlin/com/knu/mockin/model/entity/UserWithKeyPair.kt
+++ b/src/main/kotlin/com/knu/mockin/model/entity/UserWithKeyPair.kt
@@ -1,6 +1,6 @@
 package com.knu.mockin.model.entity
 
-data class UserWithMockKey(
+data class UserWithKeyPair(
     val email: String,
     val accountNumber: String,
     val appKey: String,

--- a/src/main/kotlin/com/knu/mockin/model/enum/TradeId.kt
+++ b/src/main/kotlin/com/knu/mockin/model/enum/TradeId.kt
@@ -26,12 +26,13 @@ enum class TradeId(val tradeId:String) {
     INQUIRE_CCNL("VTTS3035R"),            // 주문체결내역 조회
     CURRENT_PRICE("HHDFS00000300"),       // 해외주식 현재체결가
     TERM_PRICE("HHDFS76240000"),          // 해외주식 기간별시세
-    DAILY_CHART_PRICE("FHKST03030100"),      // 해외주식 종목/지수/환율 기간별 시세
-    SEARCH("HHDFS76410000"),     // 해외주식 조건검색
-    COUNTRIES_HOLIDAY("CTOS5011R"),      // 해외결제일자조회
+    DAILY_CHART_PRICE("FHKST03030100"),   // 해외주식 종목/지수/환율 기간별 시세
+    SEARCH("HHDFS76410000"),              // 해외주식 조건검색
+    COUNTRIES_HOLIDAY("CTOS5011R"),       // 해외결제일자조회
     PRICE_DETAIL("HHDFS76200200"),        // 해외주식 현재가상세
-    ITEM_CHART_PRICE("HHDFS76950200"),     // 해외주식 분봉조회
-    INDEX_CHART_PRICE("FHKST03030200");     // 해외지수분봉조회
+    ITEM_CHART_PRICE("HHDFS76950200"),    // 해외주식 분봉조회
+    INDEX_CHART_PRICE("FHKST03030200"),   // 해외지수분봉조회
+    NEWS_TITLE("HHPSTH60100C1");          // 해외뉴스종합
   
   
     companion object {

--- a/src/main/kotlin/com/knu/mockin/repository/UserRepository.kt
+++ b/src/main/kotlin/com/knu/mockin/repository/UserRepository.kt
@@ -1,7 +1,7 @@
 package com.knu.mockin.repository
 
 import com.knu.mockin.model.entity.User
-import com.knu.mockin.model.entity.UserWithMockKey
+import com.knu.mockin.model.entity.UserWithKeyPair
 import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import org.springframework.stereotype.Repository
@@ -17,12 +17,19 @@ interface UserRepository : ReactiveCrudRepository<User, String> {
     fun updateByEmail(email: String, accountNumber: String): Mono<User>
     fun findByEmail(email: String): Mono<User>
 
-    @Query("select u.email, u.account_number, m.app_key, m.app_secret " +
+    @Query(
+        "select u.email, u.account_number, m.app_key, m.app_secret " +
             "from user as u " +
             "inner join mock_key as m on u.email = m.email " +
             "where u.email = :email")
-    fun findByEmailWithMockKey(email: String): Mono<UserWithMockKey>
+    fun findByEmailWithMockKey(email: String): Mono<UserWithKeyPair>
 
+    @Query(
+        "select u.email, u.account_number, r.app_key, r.app_secret " +
+            "from user as u " +
+            "inner join real_key as r on u.email = r.email " +
+            "where u.email = :email")
+    fun findByEmailWithRealKey(email: String): Mono<UserWithKeyPair>
     @Query("update user set verified = true where email = :email")
     fun verifyEmailByEmail(email: String): Mono<User>
 }

--- a/src/test/kotlin/com/knu/mockin/controller/BasicRealControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/BasicRealControllerTest.kt
@@ -100,4 +100,20 @@ class BasicRealControllerTest (
             responseBody(RestDocsUtils.readJsonFile(uri, "responseDtoDescription.json").toBody())
         )
     }
+
+    "GET /basic/news-title" {
+        val uri = "${baseUri}/news-title"
+        val requestParams = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto NewsTitleRequestParameterDto::class.java
+        val expectedDto = RestDocsUtils.readJsonFile(uri, "responseDto.json") toDto KISNewsTitleResponseDto::class.java
+
+        coEvery { basicRealService.getNewsTitle(any()) } returns expectedDto
+
+        val response = mockMvc.getWithParams(uri, requestParams, expectedDto)
+
+        response.makeDocument(
+            uri,
+            parameters(RestDocsUtils.readJsonFile(uri, "requestDtoDescription.json").toPairs()),
+            responseBody(RestDocsUtils.readJsonFile(uri, "responseDtoDescription.json").toBody())
+        )
+    }
 })

--- a/src/test/kotlin/com/knu/mockin/dsl/RestDocsUtils.kt
+++ b/src/test/kotlin/com/knu/mockin/dsl/RestDocsUtils.kt
@@ -38,7 +38,7 @@ object RestDocsUtils {
         val fieldDescriptions = mutableListOf<Pair<Field, String>>()
 
         jsonNode.fieldNames().forEach { fieldName ->
-            if (fieldName.contains("output")) {
+            if (fieldName.contains("output") || fieldName.contains("outblock")) {
                 fieldDescriptions.addAll(jsonNode[fieldName].processOutput(fieldName))
             }else{
                 if(fieldName in listOf("expire_in")){

--- a/src/test/resources/json/basic/news-title/requestDto.json
+++ b/src/test/resources/json/basic/news-title/requestDto.json
@@ -1,0 +1,5 @@
+{
+  "queryDate": "",
+  "queryTime": "",
+  "email": "test@naver.com"
+}

--- a/src/test/resources/json/basic/news-title/requestDtoDescription.json
+++ b/src/test/resources/json/basic/news-title/requestDtoDescription.json
@@ -1,0 +1,5 @@
+{
+  "queryDate": "조회일자, 공백 또는 YYYYMMDD",
+  "queryTime": "조회시간, 공백 또는 HHMMSS",
+  "email": "이메일"
+}

--- a/src/test/resources/json/basic/news-title/responseDto.json
+++ b/src/test/resources/json/basic/news-title/responseDto.json
@@ -1,0 +1,35 @@
+{
+  "rt_cd": "0",
+  "msg_cd": "MCA00000",
+  "msg1": "정상처리 되었습니다.",
+  "outblock1": [
+    {
+      "info_gb": "t",
+      "news_key": "AKR20241022126800016",
+      "data_dt": "20241022",
+      "data_tm": "163221",
+      "class_cd": "01",
+      "class_name": "시황",
+      "source": "연합미국",
+      "nation_cd": "US",
+      "exchange_cd": "",
+      "symb": "",
+      "symb_name": "",
+      "title": "[서환-마감] 美대선 변동성에 1,380원대…4.90원↑"
+    },
+    {
+      "info_gb": "t",
+      "news_key": "ICH727079",
+      "data_dt": "20241022",
+      "data_tm": "162303",
+      "class_cd": "05",
+      "class_name": "종목리포트",
+      "source": "연합미국",
+      "nation_cd": "US",
+      "exchange_cd": "NYS",
+      "symb": "SLB",
+      "symb_name": "슐럼버거",
+      "title": "SLB, 해외 부문 성장 둔화 지속 예상 서스퀘하나"
+    }
+  ]
+}

--- a/src/test/resources/json/basic/news-title/responseDtoDescription.json
+++ b/src/test/resources/json/basic/news-title/responseDtoDescription.json
@@ -1,0 +1,21 @@
+{
+  "rt_cd": "성공 여부",
+  "msg_cd": "응답코드",
+  "msg1": "응답 메세지",
+  "outblock1": [
+    {
+      "info_gb": "뉴스",
+      "news_key": "뉴스키",
+      "data_dt": "조회일자",
+      "data_tm": "조회시간",
+      "class_cd": "중분류",
+      "class_name": "중분류명",
+      "source": "연합미국",
+      "nation_cd": "국가코드",
+      "exchange_cd": "거래소코드",
+      "symb": "종목코드",
+      "symb_name": "종목명",
+      "title": "제목"
+    }
+  ]
+}


### PR DESCRIPTION
## **PR**

### 작업 내용

- 해외뉴스종합 API 추가
---
### 참고 사항

구현 중 Basic 쪽 내부를 좀 더 자세히 볼 수 있었는데,
trading 쪽 포함해서 리팩토링할만한 요소가 많이 보이네요.
1. kis-api 쪽 uri와 controller 이름이 일치하지 않음 (quotations여야 하는데, basic임)
-> kis-api 쪽의 구분을 따라가야, api docs를 볼 때 혼동하는 경우가 적을 거 같아요.
-> 귀찮더라도 컨트롤러와 서비스도 kis-api 쪽에서 나눠진 것과 똑같이 맞추는 게 좋을 거 같습니다.

2. basic과 basic-real이 dto에서는 구분 안됨.
-> 컨트롤러와 서비스 상에서는 나뉘어져 있는데
-> dto에서는 나뉘지 않아서 만들 때 헷갈리네요.

3. kisClient 측 요청에서 보이는 중복 코드
-> 현재 webClient.요청()... 이 많이 나오는데, 
-> 이 부분은 get, post 요청 각각 함수로 하나씩 만들면
코드 중복 없이 훨씬 더 깔끔하게 재사용할 수 있을 거 같습니다.

몇 개 더 보이기는 하는데 나머지 리팩토링 사항은 앞으로 하나씩 해나가 봅시다!

---
### ✏ Git Close
#98 
