### PR TITLE
Refactor/issue #100

### DIFF
--- a/src/main/kotlin/com/knu/mockin/kisclient/KISBasicClient.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISBasicClient.kt
@@ -21,51 +21,51 @@ class KISBasicClient (
     private val quotationUrl = "/uapi/overseas-price/v1/quotations"
 
     fun getCurrentPrice(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISCurrentPriceRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISCurrentPriceRequestParameterDto
     ) : Mono<KISCurrentPriceResponseDto> {
-        val targetUri = HttpUtils.buildUri("${quotationUrl}/price", requestParameter)
-        return webClientMock.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISCurrentPriceResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${quotationUrl}/price", parameterDto)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISCurrentPriceResponseDto::class.java
+        )
     }
 
     fun getTermPrice(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISTermPriceRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISTermPriceRequestParameterDto
     ) : Mono<KISTermPriceResponseDto> {
-        val targetUri = HttpUtils.buildUri("${quotationUrl}/dailyprice", requestParameter)
-        return webClientMock.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISTermPriceResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${quotationUrl}/dailyprice", parameterDto)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISTermPriceResponseDto::class.java
+        )
     }
 
     fun getDailyChartPrice(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISDailyChartPriceRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISDailyChartPriceRequestParameterDto
     ) : Mono<KISDailyChartPriceResponseDto> {
-        val targetUri = HttpUtils.buildUri("${quotationUrl}/inquire-daily-chartprice", requestParameter)
-        return webClientMock.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISDailyChartPriceResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${quotationUrl}/inquire-daily-chartprice", parameterDto)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISDailyChartPriceResponseDto::class.java
+        )
     }
 
     fun getSearch(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISSearchRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISSearchRequestParameterDto
     ) : Mono<KISSearchResponseDto> {
-        val targetUri = HttpUtils.buildUri("${quotationUrl}/inquire-search", requestParameter)
-        return webClientMock.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISSearchResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${quotationUrl}/inquire-search", parameterDto)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISSearchResponseDto::class.java
+        )
     }
 
 }

--- a/src/main/kotlin/com/knu/mockin/kisclient/KISBasicRealClient.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISBasicRealClient.kt
@@ -16,74 +16,80 @@ class KISBasicRealClient (
     private val stockQuotationUrl = "/uapi/overseas-stock/v1/quotations"
 
     fun getCountriesHoliday(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISCountriesHolidayRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISCountriesHolidayRequestParameterDto
     ) :Mono<KISCountriesHolidayResponseDto> {
-        val targetUri = HttpUtils.buildUri("${stockQuotationUrl}/countries-holiday", requestParameter)
-        return webClientReal.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISCountriesHolidayResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${stockQuotationUrl}/countries-holiday", parameterDto)
+
+        return webClientReal.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISCountriesHolidayResponseDto::class.java
+        )
     }
 
     fun getPriceDetail(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISPriceDetailRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISPriceDetailRequestParameterDto
     ): Mono<KISPriceDetailResponseDto> {
-        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/price-detail", requestParameter)
-        return webClientReal.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISPriceDetailResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/price-detail", parameterDto)
+
+        return webClientReal.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISPriceDetailResponseDto::class.java
+        )
     }
 
     fun getItemChartPrice(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISItemChartPriceRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISItemChartPriceRequestParameterDto
     ): Mono<KISItemChartPriceResponseDto> {
-        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/inquire-time-itemchartprice", requestParameter)
-        return webClientReal.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISItemChartPriceResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/inquire-time-itemchartprice", parameterDto)
+
+        return webClientReal.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISItemChartPriceResponseDto::class.java
+        )
     }
 
     fun getIndexChartPrice(
-            header: KISOverSeaRequestHeaderDto,
-            requestParameter: KISIndexChartPriceRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISIndexChartPriceRequestParameterDto
     ): Mono<KISIndexChartPriceResponseDto> {
-        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/inquire-time-indexchartprice", requestParameter)
-        return webClientReal.get()
-                .uri(targetUri)
-                .headers { HttpUtils.addHeaders(it, header) }
-                .retrieve()
-                .bodyToMono(KISIndexChartPriceResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/inquire-time-indexchartprice", parameterDto)
+
+        return webClientReal.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISIndexChartPriceResponseDto::class.java
+        )
     }
 
     fun getSearchInfo(
-        header: KISOverSeaRequestHeaderDto,
-        requestParameter: KISSearchInfoRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISSearchInfoRequestParameterDto
     ): Mono<KISSearchInfoResponseDto> {
-        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/search-info", requestParameter)
-        return webClientReal.get()
-            .uri(targetUri)
-            .headers { HttpUtils.addHeaders(it, header) }
-            .retrieve()
-            .bodyToMono(KISSearchInfoResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/search-info", parameterDto)
+
+        return webClientReal.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISSearchInfoResponseDto::class.java
+        )
     }
     
     fun getNewsTitle(
-        header: KISOverSeaRequestHeaderDto,
-        requestParameter: KISNewsTitleRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISNewsTitleRequestParameterDto
     ): Mono<KISNewsTitleResponseDto> {
-        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/news-title", requestParameter)
-        return webClientReal.get()
-            .uri(targetUri)
-            .headers { HttpUtils.addHeaders(it, header) }
-            .retrieve()
-            .bodyToMono(KISNewsTitleResponseDto::class.java)
+        val targetUri = HttpUtils.buildUri("${priceQuotationUrl}/news-title", parameterDto)
+
+        return webClientReal.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISNewsTitleResponseDto::class.java
+        )
     }
 }

--- a/src/main/kotlin/com/knu/mockin/kisclient/KISClientExtension.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISClientExtension.kt
@@ -1,0 +1,36 @@
+package com.knu.mockin.kisclient
+
+import com.knu.mockin.model.dto.kisheader.request.KISOverSeaRequestHeaderDto
+import com.knu.mockin.util.HttpUtils
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+fun <T: Any, R:Any> WebClient.postWithBody(
+    uri: String,
+    headerDto: KISOverSeaRequestHeaderDto? = null,
+    bodyDto: T,
+    responseType: Class<R>
+): Mono<R> {
+    return this.post()
+        .uri(uri)
+        .headers {
+            if (headerDto != null) {
+                HttpUtils.addHeaders(it, headerDto)
+            }
+        }
+        .bodyValue(bodyDto)
+        .retrieve()
+        .bodyToMono(responseType)
+}
+
+fun <T: Any> WebClient.getWithParams(
+    uri: String,
+    headerDto: KISOverSeaRequestHeaderDto,
+    responseType: Class<T>
+): Mono<T> {
+    return this.get()
+        .uri(uri)
+        .headers { HttpUtils.addHeaders(it, headerDto) }
+        .retrieve()
+        .bodyToMono(responseType)
+}

--- a/src/main/kotlin/com/knu/mockin/kisclient/KISOauth2Client.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISOauth2Client.kt
@@ -12,23 +12,26 @@ import reactor.core.publisher.Mono
 class KISOauth2Client(
     private val webClientMock: WebClient
 ) {
-    fun postApproval(kisApprovalRequestDto: KISApprovalRequestDto): Mono<ApprovalKeyResponseDto>{
-        return webClientMock
-            .post()
-            .uri("/oauth2/Approval")
-            .header("Content-Type", "application/json;charset=UTF-8")
-            .bodyValue(kisApprovalRequestDto)
-            .retrieve()
-            .bodyToMono(ApprovalKeyResponseDto::class.java)
+    val oauthUri = "/oauth2"
+    fun postApproval(
+        bodyDto: KISApprovalRequestDto
+    ): Mono<ApprovalKeyResponseDto>{
+        val uri = "$oauthUri/Approval"
+        return webClientMock.postWithBody(
+            uri = uri,
+            bodyDto = bodyDto,
+            responseType = ApprovalKeyResponseDto::class.java
+        )
     }
 
-    fun postTokenP(kisTokenRequestDto: KISTokenRequestDto): Mono<AccessTokenAPIResponseDto> {
-        return webClientMock
-            .post()
-            .uri("/oauth2/tokenP")
-            .header("Content-Type", "application/json;charset=UTF-8")
-            .bodyValue(kisTokenRequestDto)
-            .retrieve()
-            .bodyToMono(AccessTokenAPIResponseDto::class.java)
+    fun postTokenP(
+        bodyDto: KISTokenRequestDto
+    ): Mono<AccessTokenAPIResponseDto> {
+        val uri = "$oauthUri/tokenP"
+        return webClientMock.postWithBody(
+            uri = uri,
+            bodyDto = bodyDto,
+            responseType = AccessTokenAPIResponseDto::class.java
+        )
     }
 }

--- a/src/main/kotlin/com/knu/mockin/kisclient/KISOauth2RealClient.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISOauth2RealClient.kt
@@ -12,23 +12,26 @@ import reactor.core.publisher.Mono
 class KISOauth2RealClient (
         private val webClientReal: WebClient
 ) {
-    fun postApproval(kisApprovalRequestDto: KISApprovalRequestDto): Mono<ApprovalKeyResponseDto> {
-        return webClientReal
-                .post()
-                .uri("/oauth2/Approval")
-                .header("Content-Type", "application/json;charset=UTF-8")
-                .bodyValue(kisApprovalRequestDto)
-                .retrieve()
-                .bodyToMono(ApprovalKeyResponseDto::class.java)
+    val oauthUri = "/oauth2"
+    fun postApproval(
+        bodyDto: KISApprovalRequestDto
+    ): Mono<ApprovalKeyResponseDto> {
+        val uri = "$oauthUri/Approval"
+        return webClientReal.postWithBody(
+            uri = uri,
+            bodyDto = bodyDto,
+            responseType = ApprovalKeyResponseDto::class.java
+        )
     }
 
-    fun postTokenP(kisTokenRequestDto: KISTokenRequestDto): Mono<AccessTokenAPIResponseDto> {
-        return webClientReal
-                .post()
-                .uri("/oauth2/tokenP")
-                .header("Content-Type", "application/json;charset=UTF-8")
-                .bodyValue(kisTokenRequestDto)
-                .retrieve()
-                .bodyToMono(AccessTokenAPIResponseDto::class.java)
+    fun postTokenP(
+        bodyDto: KISTokenRequestDto
+    ): Mono<AccessTokenAPIResponseDto> {
+        val uri = "$oauthUri/tokenP"
+        return webClientReal.postWithBody(
+            uri = uri,
+            bodyDto = bodyDto,
+            responseType = AccessTokenAPIResponseDto::class.java
+        )
     }
 }

--- a/src/main/kotlin/com/knu/mockin/kisclient/KISTradingClient.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISTradingClient.kt
@@ -3,7 +3,6 @@ package com.knu.mockin.kisclient
 import com.knu.mockin.model.dto.kisheader.request.KISOverSeaRequestHeaderDto
 import com.knu.mockin.model.dto.kisrequest.trading.*
 import com.knu.mockin.model.dto.kisresponse.trading.*
-import com.knu.mockin.util.HttpUtils.addHeaders
 import com.knu.mockin.util.HttpUtils.buildUri
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -16,91 +15,95 @@ class KISTradingClient(
     private val tradingUrl = "/uapi/overseas-stock/v1/trading"
 
     fun postOrder(
-        kisOverSeaRequestHeaderDto: KISOverSeaRequestHeaderDto,
-        kisOrderRequestBodyDto: KISOrderRequestBodyDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        bodyDto: KISOrderRequestBodyDto
     ): Mono<KISOrderResponseDto> {
-        return webClientMock.post()
-            .uri("${tradingUrl}/order")
-            .headers { addHeaders(it, kisOverSeaRequestHeaderDto) }
-            .bodyValue(kisOrderRequestBodyDto)
-            .retrieve()
-            .bodyToMono(KISOrderResponseDto::class.java)
+        val uri = "${tradingUrl}/order"
+
+        return webClientMock.postWithBody(
+            uri = uri,
+            headerDto = headerDto,
+            bodyDto = bodyDto,
+            responseType = KISOrderResponseDto::class.java
+        )
     }
 
     fun postOrderReverse(
-        kisOverSeaRequestHeaderDto: KISOverSeaRequestHeaderDto,
-        kisOrderReverseRequestBodyDto: KISOrderReverseRequestBodyDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        bodyDto: KISOrderReverseRequestBodyDto
     ): Mono<KISOrderReverseResponseDto> {
-        return webClientMock.post()
-            .uri("${tradingUrl}/order-rvsecncl")
-            .headers { addHeaders(it, kisOverSeaRequestHeaderDto) }
-            .bodyValue(kisOrderReverseRequestBodyDto)
-            .retrieve()
-            .bodyToMono(KISOrderReverseResponseDto::class.java)
+        val uri = "${tradingUrl}/order-rvsecncl"
+
+        return webClientMock.postWithBody(
+            uri = uri,
+            headerDto = headerDto,
+            bodyDto = bodyDto,
+            responseType = KISOrderReverseResponseDto::class.java
+        )
     }
 
     fun getNCCS(
-        kisOverSeaRequestHeaderDto: KISOverSeaRequestHeaderDto,
-        kisnccsRequestParameterDto: KISNCCSRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISNCCSRequestParameterDto
     ): Mono<KISNCCSResponseDto>{
-        val targetUri = buildUri("${tradingUrl}/inquire-nccs", kisnccsRequestParameterDto)
+        val targetUri = buildUri("${tradingUrl}/inquire-nccs", parameterDto)
 
-        return webClientMock.get()
-            .uri(targetUri)
-            .headers{ addHeaders(it, kisOverSeaRequestHeaderDto) }
-            .retrieve()
-            .bodyToMono(KISNCCSResponseDto::class.java)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISNCCSResponseDto::class.java
+        )
     }
 
     fun getBalance(
-        kisOverSeaRequestHeaderDto: KISOverSeaRequestHeaderDto,
-        kisBalanceRequestParameterDto: KISBalanceRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISBalanceRequestParameterDto
     ): Mono<KISBalanceResponseDto>{
-        val targetUri = buildUri("${tradingUrl}/inquire-balance", kisBalanceRequestParameterDto)
+        val targetUri = buildUri("${tradingUrl}/inquire-balance", parameterDto)
 
-        return webClientMock.get()
-            .uri(targetUri)
-            .headers { addHeaders(it, kisOverSeaRequestHeaderDto) }
-            .retrieve()
-            .bodyToMono(KISBalanceResponseDto::class.java)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISBalanceResponseDto::class.java
+        )
     }
 
     fun getPsAmount(
-        kisOverSeaRequestHeaderDto: KISOverSeaRequestHeaderDto,
-        kisPsAmountRequestParameterDto: KISPsAmountRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISPsAmountRequestParameterDto
     ): Mono<KISPsAmountResponseDto>{
-        val targetUri = buildUri("${tradingUrl}/inquire-psamount", kisPsAmountRequestParameterDto)
+        val targetUri = buildUri("${tradingUrl}/inquire-psamount", parameterDto)
 
-        return webClientMock.get()
-            .uri(targetUri)
-            .headers { addHeaders(it, kisOverSeaRequestHeaderDto) }
-            .retrieve()
-            .bodyToMono(KISPsAmountResponseDto::class.java)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISPsAmountResponseDto::class.java
+        )
     }
 
     fun getPresentBalance(
-        kisOverSeaRequestHeaderDto: KISOverSeaRequestHeaderDto,
-        kisPresentBalanceRequestParameterDto: KISPresentBalanceRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISPresentBalanceRequestParameterDto
     ): Mono<KISPresentBalanceResponseDto>{
-        val targetUri = buildUri("${tradingUrl}/inquire-psamount", kisPresentBalanceRequestParameterDto)
+        val targetUri = buildUri("${tradingUrl}/inquire-psamount", parameterDto)
 
-        return webClientMock.get()
-            .uri(targetUri)
-            .headers { addHeaders(it, kisOverSeaRequestHeaderDto) }
-            .retrieve()
-            .bodyToMono(KISPresentBalanceResponseDto::class.java)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISPresentBalanceResponseDto::class.java
+        )
     }
 
     fun getCCNL(
-        kisOverSeaRequestHeaderDto: KISOverSeaRequestHeaderDto,
-        kisccnlRequestParameterDto: KISCCNLRequestParameterDto
+        headerDto: KISOverSeaRequestHeaderDto,
+        parameterDto: KISCCNLRequestParameterDto
     ): Mono<KISCCNLResponseDto>{
-        val targetUri = buildUri("${tradingUrl}/inquire-ccnl", kisccnlRequestParameterDto)
+        val targetUri = buildUri("${tradingUrl}/inquire-ccnl", parameterDto)
 
-        return webClientMock.get()
-            .uri(targetUri)
-            .headers { addHeaders(it, kisOverSeaRequestHeaderDto) }
-            .retrieve()
-            .bodyToMono(KISCCNLResponseDto::class.java)
+        return webClientMock.getWithParams(
+            uri = targetUri,
+            headerDto = headerDto,
+            responseType = KISCCNLResponseDto::class.java
+        )
     }
 }


### PR DESCRIPTION
## **PR**

### 작업 내용

- WebClient 확장 함수 구현 (get/post)
- 확장 함수 활용하여 KISWebClient 전부 리팩토링 진행

---
### 참고 사항

- get/post 공통
KISOverseaHeaderDto의 인자 이름을 headerDto로 통일

- get
parameterDto 로 인자명 통일

- post
bodyDto로 인자명 통일

---
### ✏ Git Close
#100 
