### PR TITLE
Test/issue #134

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:5.9.1")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
 
+    // reactor-test
+    testImplementation("io.projectreactor:reactor-test:3.6.11")
+
     // MockK
     testImplementation("io.mockk:mockk:1.13.12")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
@@ -106,6 +109,14 @@ tasks.jacocoTestReport {
         csv.required = false
         html.outputLocation = layout.buildDirectory.dir("jacocoHtml")
     }
+    classDirectories.setFrom(files(classDirectories.files.map {  classDir ->
+        fileTree(classDir) {
+            exclude("com/knu/mockin/model/**")
+            exclude("com/knu/mockin/config/**")
+            exclude("com/knu/mockin/kisclient/**")
+            exclude("com/knu/mockin/logging/**")
+        }
+    }))
 }
 
 tasks.jacocoTestCoverageVerification {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,6 @@ tasks.jacocoTestReport {
             exclude("com/knu/mockin/model/**")
             exclude("com/knu/mockin/config/**")
             exclude("com/knu/mockin/kisclient/**")
-            exclude("com/knu/mockin/logging/**")
         }
     }))
 }

--- a/src/test/kotlin/com/knu/mockin/aspect/ErrorAspectTest.kt
+++ b/src/test/kotlin/com/knu/mockin/aspect/ErrorAspectTest.kt
@@ -1,0 +1,141 @@
+package com.knu.mockin.aspect
+
+import com.knu.mockin.exeption.CustomException
+import com.knu.mockin.exeption.ErrorCode
+import com.knu.mockin.model.dto.kisresponse.trading.KISOrderReverseResponseDto
+import com.knu.mockin.model.dto.response.ApprovalKeyResponseDto
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.aspectj.lang.ProceedingJoinPoint
+import org.reactivestreams.Publisher
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class ErrorAspectTest: BehaviorSpec({
+    val errorAspect = ErrorAspect()
+    val joinPoint = mockk<ProceedingJoinPoint>()
+
+    Context("모든 kisclient 패키지 내에서 메소드 실행이 일어날 때"){
+        Given("정상 응답, 응답 코드 null"){
+            val response = ApprovalKeyResponseDto("key")
+
+            When("KIS로부터 응답을 받으면"){
+                every { joinPoint.proceed() } returns Mono.just(response)
+
+                Then("그 결과를 반환한다.") {
+                    val result = errorAspect.handleKISWebClientException(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectNext(response)
+                        .verifyComplete()
+                }
+            }
+        }
+
+        Given("정상 응답, 응답 성공 코드"){
+            val response = KISOrderReverseResponseDto(
+                successFailureStatus = "0",
+                responseMessage = "정상 처리되었습니다."
+            )
+
+            When("KIS의 응답의 성공코드가 0이면"){
+                every { joinPoint.proceed() } returns Mono.just(response)
+
+                Then("그 결과를 반환한다.") {
+                    val result = errorAspect.handleKISWebClientException(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectNext(response)
+                        .verifyComplete()
+                }
+            }
+        }
+
+        Given("KIS 응답 에러 403"){
+            val responseException = WebClientResponseException.create(
+                403, "Forbidden",
+                org.springframework.http.HttpHeaders(),
+                "Error body".toByteArray(),
+                null
+            )
+            When("KIS로부터 403 에러를 받으면"){
+                every { joinPoint.proceed() } returns Mono.error<WebClientResponseException>(responseException )
+
+                Then("그 결과를 반환한다.") {
+                    val result = errorAspect.handleKISWebClientException(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectErrorMatches { it is CustomException && it.errorCode == ErrorCode.FORBIDDEN }
+                        .verify()
+                }
+            }
+        }
+
+        Given("KIS 응답 에러 500"){
+            val responseException = WebClientResponseException.create(
+                500, "Internal_Server_Error",
+                org.springframework.http.HttpHeaders(),
+                "Error body".toByteArray(),
+                null
+            )
+            When("KIS로부터 500 에러를 받으면"){
+                every { joinPoint.proceed() } returns Mono.error<WebClientResponseException>(responseException )
+
+                Then("그 결과를 반환한다.") {
+                    val result = errorAspect.handleKISWebClientException(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectErrorMatches { it is CustomException && it.errorCode == ErrorCode.INTERNAL_SERVER_ERROR }
+                        .verify()
+                }
+            }
+        }
+
+        Given("정상 응답, 응답 실패 코드"){
+            val response = KISOrderReverseResponseDto(
+                successFailureStatus = "1",
+                responseMessage = "모의장이 휴장입니다."
+            )
+
+            When("KIS의 응답의 성공코드가 0이 아니면"){
+                every { joinPoint.proceed() } returns Mono.just(response)
+
+                Then("에러를 일으키고 메세지를 반환한다.") {
+                    val result = errorAspect.handleKISWebClientException(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectErrorMatches { it is CustomException &&
+                                it.errorCode == ErrorCode.KIS_API_FAILED &&
+                                it.message == "모의장이 휴장입니다."}
+                        .verify()
+                }
+            }
+        }
+
+        Given("KIS 요청에서 예측되지 못한 에러의 경우"){
+            val responseException = CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
+
+            When("알 수 없는 에러가 발생하면"){
+                every { joinPoint.proceed() } returns Mono.error<CustomException>(responseException )
+
+                Then("그 결과를 그대로 반환한다.") {
+                    val result = errorAspect.handleKISWebClientException(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectErrorMatches { it is CustomException && it.errorCode == ErrorCode.INTERNAL_SERVER_ERROR }
+                        .verify()
+                }
+            }
+        }
+
+        Given("KIS 요청 이전에 예측 불가능 에러"){
+
+            When("중간에 알 수 없는 에러가 발생하면"){
+                every { joinPoint.proceed() } throws CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
+
+                Then("그 에러를 반환한다.") {
+                    val result = errorAspect.handleKISWebClientException(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectErrorMatches { it is CustomException && it.errorCode == ErrorCode.INTERNAL_SERVER_ERROR }
+                        .verify()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/knu/mockin/aspect/LoggingAspectTest.kt
+++ b/src/test/kotlin/com/knu/mockin/aspect/LoggingAspectTest.kt
@@ -1,0 +1,38 @@
+package com.knu.mockin.aspect
+
+import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class LoggingAspectTest :BehaviorSpec({
+    val loggingAspect = LoggingAspect()
+
+    Context("컨트롤러의 모든 메소드에 대해"){
+        Given("실행 전후로"){
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            val methodSignature = mockk<MethodSignature>(relaxed = true)
+            val response = SimpleMessageResponseDto("성공")
+
+            When("필요한 데이터를 담은 로그를 남기고"){
+                every { joinPoint.proceed() } returns Mono.just(response)
+                every { joinPoint.signature } returns methodSignature
+                every { methodSignature.declaringTypeName } returns "com.knu.mockin.HealthCheckController"
+                every { methodSignature.name } returns "healthCheck"
+
+                Then("결과를 반환한다"){
+                    val result = loggingAspect.logExecutionInController(joinPoint)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectNext(response)
+                        .verifyComplete()
+                }
+            }
+
+        }
+    }
+})


### PR DESCRIPTION
## **PR**

### 작업 내용

- Reactor-test 의존성 추가
- ErrorAspect 테스트 추가
- LoggingAspect 테스트 추가

---
### 참고 사항

config, dto 등 테스트가 불필요한 패키지들을
jacoco report에서 제외하였습니다.

reactor-test 의존성을 추가했는데,
Mono, Flux 와 같은 비동기 프로그래밍을 테스트하는 도구로,
StepVerifier가 해당 의존성에서 활용하는 객체입니다.

---
### ✏ Git Close
#134 
