### PR TITLE
Test/issue #138

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,6 +114,7 @@ tasks.jacocoTestReport {
             exclude("com/knu/mockin/model/**")
             exclude("com/knu/mockin/config/**")
             exclude("com/knu/mockin/kisclient/**")
+            exclude("com/knu/mockin/util/**")
         }
     }))
 }

--- a/src/test/kotlin/com/knu/mockin/config/ConstantConfig.kt
+++ b/src/test/kotlin/com/knu/mockin/config/ConstantConfig.kt
@@ -1,0 +1,14 @@
+package com.knu.mockin.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "app")
+class ConstantConfig {
+    var user: UserConfig = UserConfig()
+
+    class UserConfig {
+        lateinit var email: String
+    }
+}

--- a/src/test/kotlin/com/knu/mockin/kisclient/KISOauth2ClientTest.kt
+++ b/src/test/kotlin/com/knu/mockin/kisclient/KISOauth2ClientTest.kt
@@ -1,0 +1,32 @@
+package com.knu.mockin.kisclient
+
+import com.knu.mockin.config.ConstantConfig
+import com.knu.mockin.model.dto.kisrequest.oauth.KISTokenRequestDto
+import com.knu.mockin.model.enum.Constant
+import com.knu.mockin.repository.UserRepository
+import com.knu.mockin.util.RedisUtil
+import com.knu.mockin.util.tag
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class KISOauth2ClientTest(
+    val kisOauth2Client: KISOauth2Client,
+    val userRepository: UserRepository,
+    private val constantConfig: ConstantConfig
+): FunSpec({
+    xcontext("KISOauth2Client 테스트"){
+        val user = userRepository.findByEmailWithMockKey(constantConfig.user.email).block()
+
+        test("postTokenP 테스트 후 redis에 저장"){
+            val requestDto = KISTokenRequestDto(
+                grantType = "client_credentials",
+                appKey = user!!.appKey,
+                appSecret = user.appSecret)
+            val dto = kisOauth2Client.postTokenP(requestDto).awaitSingle()
+
+            RedisUtil.saveToken(user.email tag Constant.MOCK, dto.accessToken)
+        }
+    }
+})

--- a/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
+++ b/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
@@ -1,0 +1,51 @@
+package com.knu.mockin.kisclient
+
+import com.knu.mockin.dsl.RestDocsUtils
+import com.knu.mockin.dsl.toDto
+import com.knu.mockin.exeption.CustomException
+import com.knu.mockin.exeption.ErrorCode
+import com.knu.mockin.model.dto.request.trading.BalanceRequestParameterDto
+import com.knu.mockin.model.dto.request.trading.OrderRequestBodyDto
+import com.knu.mockin.model.dto.request.trading.asDomain
+import com.knu.mockin.model.enum.TradeId
+import com.knu.mockin.repository.UserRepository
+import com.knu.mockin.service.util.ServiceUtil
+import io.kotest.core.spec.style.FunSpec
+import org.reactivestreams.Publisher
+import org.springframework.boot.test.context.SpringBootTest
+import reactor.test.StepVerifier
+
+@SpringBootTest
+class KISTradingClientTest(
+    val kisTradingClient: KISTradingClient,
+    val userRepository: UserRepository
+): FunSpec({
+    xcontext("TradingClient 테스트"){
+        val baseUri = "trading"
+        val user = userRepository.findByEmailWithMockKey("rkdgustn123@knu.ac.kr").block()
+
+        test("postOrder 요청 보내기"){
+            val uri = "${baseUri}/order"
+            val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto OrderRequestBodyDto::class.java
+            val bodyDto = requestDto.asDomain(user!!.accountNumber)
+            val headerDto = ServiceUtil.createHeader(user, requestDto.transactionId)
+
+            val response = kisTradingClient.postOrder(headerDto, bodyDto)
+
+            StepVerifier.create(response as Publisher<out Any>)
+                .expectErrorMatches{ it is CustomException && it.errorCode == ErrorCode.KIS_API_FAILED }
+                .verify()
+        }
+
+        test("getBalance 요청 보내기"){
+            val uri = "${baseUri}/balance"
+            val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto BalanceRequestParameterDto::class.java
+            val bodyDto = requestDto.asDomain(user!!.accountNumber)
+            val headerDto = ServiceUtil.createHeader(user, TradeId.getTradeIdByEnum(TradeId.INQUIRE_BALANCE))
+
+            val response = kisTradingClient.getBalance(headerDto, bodyDto).block()
+
+            println(response)
+        }
+    }
+})

--- a/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
+++ b/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
@@ -4,9 +4,7 @@ import com.knu.mockin.dsl.RestDocsUtils
 import com.knu.mockin.dsl.toDto
 import com.knu.mockin.exeption.CustomException
 import com.knu.mockin.exeption.ErrorCode
-import com.knu.mockin.model.dto.request.trading.BalanceRequestParameterDto
-import com.knu.mockin.model.dto.request.trading.OrderRequestBodyDto
-import com.knu.mockin.model.dto.request.trading.asDomain
+import com.knu.mockin.model.dto.request.trading.*
 import com.knu.mockin.model.enum.TradeId
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.service.util.ServiceUtil
@@ -37,6 +35,30 @@ class KISTradingClientTest(
                 .verify()
         }
 
+        test("postOrderReverse 요청 보내기"){
+            val uri = "${baseUri}/order-reverse"
+            val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto OrderReverseRequestBodyDto::class.java
+            val bodyDto = requestDto.asDomain(user!!.accountNumber)
+            val headerDto = ServiceUtil.createHeader(user, requestDto.transactionId)
+
+            val response = kisTradingClient.postOrderReverse(headerDto, bodyDto)
+
+            StepVerifier.create(response as Publisher<out Any>)
+                .expectErrorMatches{ it is CustomException && it.errorCode == ErrorCode.KIS_API_FAILED }
+                .verify()
+        }
+
+        test("getNCCS 요청 보내기"){
+            val uri = "${baseUri}/nccs"
+            val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto NCCSRequestParameterDto::class.java
+            val bodyDto = requestDto.asDomain(user!!.accountNumber)
+            val headerDto = ServiceUtil.createHeader(user, TradeId.getTradeIdByEnum(TradeId.INQUIRE_NCCS))
+
+            val response = kisTradingClient.getNCCS(headerDto, bodyDto).block()
+
+            println(response)
+        }
+
         test("getBalance 요청 보내기"){
             val uri = "${baseUri}/balance"
             val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto BalanceRequestParameterDto::class.java
@@ -44,6 +66,39 @@ class KISTradingClientTest(
             val headerDto = ServiceUtil.createHeader(user, TradeId.getTradeIdByEnum(TradeId.INQUIRE_BALANCE))
 
             val response = kisTradingClient.getBalance(headerDto, bodyDto).block()
+
+            println(response)
+        }
+
+        test("getPsAmount 요청 보내기"){
+            val uri = "${baseUri}/psamount"
+            val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto PsAmountRequestParameterDto::class.java
+            val bodyDto = requestDto.asDomain(user!!.accountNumber)
+            val headerDto = ServiceUtil.createHeader(user, TradeId.getTradeIdByEnum(TradeId.INQUIRE_PSAMOUNT))
+
+            val response = kisTradingClient.getPsAmount(headerDto, bodyDto).block()
+
+            println(response)
+        }
+
+        test("getPresentBalance 요청 보내기"){
+            val uri = "${baseUri}/present-balance"
+            val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto PresentBalanceRequestParameterDto::class.java
+            val bodyDto = requestDto.asDomain(user!!.accountNumber)
+            val headerDto = ServiceUtil.createHeader(user, TradeId.getTradeIdByEnum(TradeId.INQUIRE_PRESENT_BALANCE))
+
+            val response = kisTradingClient.getPresentBalance(headerDto, bodyDto).block()
+
+            println(response)
+        }
+
+        test("getCCNL 요청 보내기"){
+            val uri = "${baseUri}/ccnl"
+            val requestDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto CCNLRequestParameterDto::class.java
+            val bodyDto = requestDto.asDomain(user!!.accountNumber)
+            val headerDto = ServiceUtil.createHeader(user, TradeId.getTradeIdByEnum(TradeId.INQUIRE_CCNL))
+
+            val response = kisTradingClient.getCCNL(headerDto, bodyDto).block()
 
             println(response)
         }

--- a/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
+++ b/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
@@ -1,5 +1,6 @@
 package com.knu.mockin.kisclient
 
+import com.knu.mockin.config.ConstantConfig
 import com.knu.mockin.dsl.RestDocsUtils
 import com.knu.mockin.dsl.toDto
 import com.knu.mockin.exeption.CustomException
@@ -16,11 +17,12 @@ import reactor.test.StepVerifier
 @SpringBootTest
 class KISTradingClientTest(
     val kisTradingClient: KISTradingClient,
-    val userRepository: UserRepository
+    val userRepository: UserRepository,
+    private val constantConfig: ConstantConfig
 ): FunSpec({
     xcontext("TradingClient 테스트"){
         val baseUri = "trading"
-        val user = userRepository.findByEmailWithMockKey("rkdgustn123@knu.ac.kr").block()
+        val user = userRepository.findByEmailWithMockKey(constantConfig.user.email).block()
 
         test("postOrder 요청 보내기"){
             val uri = "${baseUri}/order"


### PR DESCRIPTION
## **PR**

### 작업 내용

- KISClient 요청을 테스트 코드로 실행할 수 있도록 테스트 추가
- 이메일을 상수로 활용할 수 있도록 설정 파일 추가

---
### 참고 사항

해당 테스트는 실제 통신이 이루어지므로,
테스트 시 db 및 redis가 켜져 있어야 합니다.

위 의존성 및 실제 네트워크 환경 변동 문제로 check가 무작위로 실패할 가능성을 감안하여
해당 테스트는 check에서는 실행하지 않도록 xcontext를 활용했습니다.
만약 해당 테스트를 실행하다가 x를 지운 채 커밋하면, check에서 failed가 나므로 주의해주세요.

또한 위의 이유로 테스트 커버리지에서 kisclient 관련 패키지들은 제외했습니다.

실제 사용자를 읽어오기 위한 이메일의 경우 상수 처리 했습니다.
application.yml 을 제외한 아무 yml 파일 안에
app.user.email = 이메일
이렇게 정의하면 됩니다.

---
### ✏ Git Close
#138 
