### PR TITLE
Test/issue #140

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,6 +115,7 @@ tasks.jacocoTestReport {
             exclude("com/knu/mockin/config/**")
             exclude("com/knu/mockin/kisclient/**")
             exclude("com/knu/mockin/util/**")
+            exclude("com/knu/mockin/MockinApplicationKt.class")
         }
     }))
 }

--- a/src/test/kotlin/com/knu/mockin/security/AuthenticationTest.kt
+++ b/src/test/kotlin/com/knu/mockin/security/AuthenticationTest.kt
@@ -1,0 +1,41 @@
+package com.knu.mockin.security
+
+import com.knu.mockin.exeption.CustomException
+import com.knu.mockin.exeption.ErrorCode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class AuthenticationTest: BehaviorSpec({
+    val jwtUtil = mockk<JwtUtil>()
+    val customUserDetailsService = mockk<CustomUserDetailsService>()
+    val jwtAuthenticationManager = JwtAuthenticationManager(jwtUtil, customUserDetailsService)
+
+    Context("JwtAuthenticationManager 테스트"){
+        Given("authenticate 테스트"){
+            val invalidToken = BearerToken("invalid_token")
+            val username = "test@naver.com"
+
+            val userDetail =org.springframework.security.core.userdetails.User.withUsername("other name")
+                .password("1111")
+                .roles("USER")
+                .build()
+
+            When("JWT가 inValid 하면"){
+                every { jwtUtil.getUsername(invalidToken) } returns username
+                every { customUserDetailsService.findByUsername(username) } returns Mono.just(userDetail)
+                every { jwtUtil.isValid(invalidToken, userDetail) } returns false
+
+                Then("에러를 반환한다."){
+                    val result = jwtAuthenticationManager.authenticate(invalidToken)
+                    StepVerifier.create(result as Publisher<out Any>)
+                        .expectErrorMatches { it is InvalidBearerToken && it.message == "적절한 토큰이 없어 접근이 거부당했습니다." }
+                        .verify()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/knu/mockin/security/JwtUtilTest.kt
+++ b/src/test/kotlin/com/knu/mockin/security/JwtUtilTest.kt
@@ -1,0 +1,113 @@
+package com.knu.mockin.security
+
+import com.knu.mockin.model.enum.Constant.JWT
+import com.knu.mockin.util.RedisUtil
+import com.knu.mockin.util.tag
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jws
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.redis.core.RedisTemplate
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+
+class JwtUtilTest :BehaviorSpec({
+    val redisTemplate = mockk<RedisTemplate<String, String>>()
+    RedisUtil.init(redisTemplate)
+    val username = "test@naver.com"
+    val password = "1111"
+
+    beforeTest {
+        every { RedisUtil.saveToken(username tag JWT, any(), Duration.ofMinutes(60) ) } returns Unit
+    }
+
+    Context("JwtUtil 테스트"){
+        val jwtUtil = JwtUtil()
+        val token = jwtUtil.generate(username)
+
+        Given("generate 테스트") {
+
+            When("메소드가 실행되면") {
+
+                Then("토큰을 생성한 후 redis에 저장한다.") {
+                    jwtUtil.generate(username)
+                    verify {
+                        RedisUtil.saveToken(username tag JWT, any(), Duration.ofMinutes(60) )
+                    }
+                }
+            }
+        }
+
+        Given("getUsername 테스트"){
+
+            When("메소드가 실행되면") {
+
+                Then("토큰에 담긴 사용자 이름을 가져온다.") {
+                    val result = jwtUtil.getUsername(token)
+                    result shouldBe username
+                }
+            }
+        }
+
+        Given("isValid 테스트"){
+            val userDetails =org.springframework.security.core.userdetails.User.withUsername(username)
+                .password(password)
+                .roles("USER")
+                .build()
+
+            When("토큰이 valid한 경우") {
+                every { RedisUtil.getToken(username tag JWT) } returns token.value
+
+                Then("true를 반환한다.") {
+                    val result = jwtUtil.isValid(token, userDetails)
+                    result shouldBe true
+                }
+            }
+
+            xWhen("토큰이 만료된 경우"){
+                every { RedisUtil.getToken(username tag JWT) } returns token.value
+
+                Then("false를 반환한다.") {
+                    val result = jwtUtil.isValid(token, userDetails)
+                    result shouldBe false
+                }
+            }
+
+            val otherUser =org.springframework.security.core.userdetails.User.withUsername("other name")
+                .password(password)
+                .roles("USER")
+                .build()
+            When("사용자 이름이 일치하지 않는 경우"){
+                every { RedisUtil.getToken(username tag JWT) } returns token.value
+
+                Then("false를 반환한다.") {
+                    val isInvalidUserResult = jwtUtil.isValid(token, otherUser)
+                    isInvalidUserResult shouldBe false
+                }
+            }
+
+            When("저장된 토큰과 값이 다른 경우"){
+                every { RedisUtil.getToken(username tag JWT) } returns "other value"
+
+                Then("false를 반환한다.") {
+                    val isInvalidUserResult = jwtUtil.isValid(token, userDetails)
+                    isInvalidUserResult shouldBe false
+                }
+            }
+
+            When("사용자 정보가 없는 경우"){
+                every { RedisUtil.getToken(username tag JWT) } returns token.value
+
+                Then("false를 반환한다.") {
+                    val isInvalidUserResult = jwtUtil.isValid(token, null)
+                    isInvalidUserResult shouldBe false
+                }
+            }
+        }
+    }
+
+})

--- a/src/test/kotlin/com/knu/mockin/security/handler/JwtAccessDeniedHandlerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/security/handler/JwtAccessDeniedHandlerTest.kt
@@ -1,0 +1,45 @@
+package com.knu.mockin.security.handler
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class JwtAccessDeniedHandlerTest: BehaviorSpec({
+    Context("JwtAccessDeniedHandler 테스트"){
+        val jwtAccessDeniedHandler = JwtAccessDeniedHandler()
+
+        Given("필터에서 토큰 검증이 실패하면"){
+            val exchange = mockk<ServerWebExchange>(relaxed = true)
+            val response = mockk<ServerHttpResponse>(relaxed = true)
+            val exception = AccessDeniedException("Access denied")
+
+            When("적절한 에러 메세지를 생성하여"){
+                every { exchange.response } returns response
+                every { response.bufferFactory() } returns DefaultDataBufferFactory.sharedInstance
+                every { response.writeWith(any()) } returns Mono.empty()
+
+                Then("메세지를 반환한다."){
+                    val result = jwtAccessDeniedHandler.handle(exchange, exception)
+
+                    StepVerifier.create(result)
+                        .verifyComplete()
+
+                    verify {
+                        response.statusCode = HttpStatus.UNAUTHORIZED
+                        response.headers.contentType = APPLICATION_JSON
+                        response.writeWith(any())
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/knu/mockin/security/handler/JwtAuthenticationEntryPointTest.kt
+++ b/src/test/kotlin/com/knu/mockin/security/handler/JwtAuthenticationEntryPointTest.kt
@@ -1,0 +1,44 @@
+package com.knu.mockin.security.handler
+
+import com.knu.mockin.security.InvalidBearerToken
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class JwtAuthenticationEntryPointTest :BehaviorSpec({
+    Context("JwtAuthenticationEntryPoint 테스트"){
+        val entryPoint = JwtAuthenticationEntryPoint()
+
+        Given("필터에서 JWT 인증에 실패하면"){
+            val exchange = mockk<ServerWebExchange>(relaxed = true)
+            val response = mockk<ServerHttpResponse>(relaxed = true)
+            val exception = InvalidBearerToken("Authentication failed")
+
+            When("해당하는 응답 메세지를 생성하여"){
+                every { exchange.response } returns response
+                every { response.bufferFactory() } returns DefaultDataBufferFactory.sharedInstance
+                every { response.writeWith(any()) } returns Mono.empty()
+
+                Then("메세지를 반환한다."){
+                    val result = entryPoint.commence(exchange, exception)
+                    StepVerifier.create(result)
+                        .verifyComplete()
+
+                    verify {
+                        response.statusCode = HttpStatus.UNAUTHORIZED
+                        response.headers.contentType = APPLICATION_JSON
+                        response.writeWith(any())
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## **PR**

### 작업 내용

- JwtUtil 테스트 추가
- Jwt 에러 핸들러 테스트 추가
- Authentication 테스트 추가

---
### 참고 사항

JwtUtil의 isValid 함수에서
토큰이 만료된 케이스에 대한 테스트는 하지 못했습니다.
내부 값을 모킹하고 싶은데, 의도한 대로 동작을 안하더라구요.

때문에 코드 커버리지는 100%지만, 브랜치 커버리지는 87%가 나옵니다.

---
### ✏ Git Close
#140 
