### PR TITLE
Test/issue #146

### DIFF
--- a/src/test/kotlin/com/knu/mockin/security/JwtUtilTest.kt
+++ b/src/test/kotlin/com/knu/mockin/security/JwtUtilTest.kt
@@ -68,11 +68,13 @@ class JwtUtilTest :BehaviorSpec({
                 }
             }
 
-            xWhen("토큰이 만료된 경우"){
-                every { RedisUtil.getToken(username tag JWT) } returns token.value
+            val expiredToken = jwtUtil.generate(username, -10)
+
+            When("토큰이 만료된 경우"){
+                every { RedisUtil.getToken(username tag JWT) } returns expiredToken.value
 
                 Then("false를 반환한다.") {
-                    val result = jwtUtil.isValid(token, userDetails)
+                    val result = jwtUtil.isValid(expiredToken, userDetails)
                     result shouldBe false
                 }
             }

--- a/src/test/kotlin/com/knu/mockin/service/login/EmailServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/login/EmailServiceTest.kt
@@ -17,7 +17,6 @@ import jakarta.mail.MessagingException
 import jakarta.mail.internet.MimeMessage
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.mail.javamail.JavaMailSender
-import org.springframework.test.util.ReflectionTestUtils
 import java.util.concurrent.TimeUnit
 
 class EmailServiceTest(
@@ -31,7 +30,7 @@ class EmailServiceTest(
     val baseUri = "auth"
 
     beforeTest{
-        ReflectionTestUtils.setField(emailService, "serviceName", "mockin")
+        emailService.serviceName = "mockin"
     }
 
     Context("sendEmail 함수의 경우"){


### PR DESCRIPTION
## **PR**

### 작업 내용

- [이전 PR](https://github.com/Mockin-2024/backend/pull/141)에서 발견한 문제를 해결
- EmailService 테스트 개선
- JwtUtil 리팩토링 및 테스트 개선

---
### 참고 사항

JwtUtil의 isValid 함수에서 unexpired는 불필요한 변수입니다.
```val claims = parser.parseClaimsJws(token.value).body```
에서 만료된 토큰일 경우 에러가 남.

따라서 해당 변수를 삭제하고, 토큰 생성 시 expiration 시간 설정을 가능하게 하여,
만료된 토큰을 테스트할 수 있도록 개선했습니다.

이번 변경을 통해 라인 및 브랜치 커버리지 100%가 되었습니다!!

---
### ✏ Git Close
#146 
