### PR TITLE
Feat/issue #152

### DIFF
--- a/src/main/kotlin/com/knu/mockin/model/enum/Constant.kt
+++ b/src/main/kotlin/com/knu/mockin/model/enum/Constant.kt
@@ -4,4 +4,5 @@ object Constant {
     const val JWT: String = "jwt"
     const val REAL: String = "real"
     const val MOCK: String = "mock"
+    const val CLIENT_CREDENTIAL: String = "client_credentials"
 }

--- a/src/main/kotlin/com/knu/mockin/service/AccountService.kt
+++ b/src/main/kotlin/com/knu/mockin/service/AccountService.kt
@@ -1,16 +1,21 @@
 package com.knu.mockin.service
 
 import com.knu.mockin.exception.ErrorCode
+import com.knu.mockin.kisclient.KISOauth2Client
+import com.knu.mockin.kisclient.KISOauth2RealClient
+import com.knu.mockin.model.dto.kisrequest.oauth.KISTokenRequestDto
 import com.knu.mockin.model.dto.request.account.KeyPairRequestDto
 import com.knu.mockin.model.dto.request.account.UserAccountNumberRequestDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.model.entity.MockKey
 import com.knu.mockin.model.entity.RealKey
+import com.knu.mockin.model.enum.Constant.CLIENT_CREDENTIAL
 import com.knu.mockin.repository.MockKeyRepository
 import com.knu.mockin.repository.RealKeyRepository
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.util.ExtensionUtil.orThrow
 import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.stereotype.Service
 
@@ -18,16 +23,14 @@ import org.springframework.stereotype.Service
 class AccountService(
     private val userRepository: UserRepository,
     private val mockKeyRepository: MockKeyRepository,
-    private val realKeyRepository: RealKeyRepository
+    private val realKeyRepository: RealKeyRepository,
+    private val kisOauth2Client: KISOauth2Client,
+    private val kisOauth2RealClient: KISOauth2RealClient
 ) {
     suspend fun patchUser(
         userAccountNumberRequestDto: UserAccountNumberRequestDto,
         email: String
     ): SimpleMessageResponseDto {
-        userRepository.findByEmail(email)
-            .orThrow(ErrorCode.USER_NOT_FOUND)
-            .awaitFirst()
-
         userRepository.updateByEmail(email, userAccountNumberRequestDto.accountNumber)
             .awaitSingleOrNull()
 
@@ -38,16 +41,15 @@ class AccountService(
         keyPairRequestDto: KeyPairRequestDto,
         email: String
     ): SimpleMessageResponseDto {
-        val user = userRepository.findByEmail(email)
-            .orThrow(ErrorCode.USER_NOT_FOUND)
-            .awaitFirst()
+        validateMockKey(keyPairRequestDto)
 
         val mockKey = MockKey(
-            email = user.email,
+            email = email,
             appKey = keyPairRequestDto.appKey,
             appSecret = keyPairRequestDto.appSecret,
         )
         mockKeyRepository.save(mockKey).awaitSingleOrNull()
+
         return SimpleMessageResponseDto("Register Complete")
     }
 
@@ -55,18 +57,35 @@ class AccountService(
         keyPairRequestDto: KeyPairRequestDto,
         email: String
     ): SimpleMessageResponseDto {
-        val user = userRepository.findByEmail(email)
-            .orThrow(ErrorCode.USER_NOT_FOUND)
-            .awaitFirst()
+        validateRealKey(keyPairRequestDto)
 
         val realKey = RealKey(
-            email = user.email,
+            email = email,
             appKey = keyPairRequestDto.appKey,
             appSecret = keyPairRequestDto.appSecret,
         )
         realKeyRepository.save(realKey).awaitSingleOrNull()
+
         return SimpleMessageResponseDto("Register Complete")
     }
 
+    private suspend fun validateMockKey(keyPairRequestDto: KeyPairRequestDto) {
+        val requestDto = KISTokenRequestDto(
+            grantType = CLIENT_CREDENTIAL,
+            appKey = keyPairRequestDto.appKey,
+            appSecret = keyPairRequestDto.appSecret
+        )
 
+        kisOauth2Client.postTokenP(requestDto).awaitSingle()
+    }
+
+    private suspend fun validateRealKey(keyPairRequestDto: KeyPairRequestDto) {
+        val requestDto = KISTokenRequestDto(
+            grantType = CLIENT_CREDENTIAL,
+            appKey = keyPairRequestDto.appKey,
+            appSecret = keyPairRequestDto.appSecret
+        )
+
+        kisOauth2RealClient.postTokenP(requestDto).awaitSingle()
+    }
 }

--- a/src/main/kotlin/com/knu/mockin/service/Oauth2Service.kt
+++ b/src/main/kotlin/com/knu/mockin/service/Oauth2Service.kt
@@ -8,6 +8,7 @@ import com.knu.mockin.model.dto.kisrequest.oauth.KISTokenRequestDto
 import com.knu.mockin.model.dto.response.AccessTokenAPIResponseDto
 import com.knu.mockin.model.dto.response.ApprovalKeyResponseDto
 import com.knu.mockin.model.enum.Constant
+import com.knu.mockin.model.enum.Constant.CLIENT_CREDENTIAL
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.util.ExtensionUtil.orThrow
 import com.knu.mockin.util.RedisUtil
@@ -30,7 +31,7 @@ class Oauth2Service(
             .awaitFirst()
 
         val requestDto = KISApprovalRequestDto(
-            grantType = "client_credentials",
+            grantType = CLIENT_CREDENTIAL,
             appKey = user.appKey,
             secretKey = user.appSecret)
         return kisOauth2Client.postApproval(requestDto).awaitSingle()
@@ -44,7 +45,7 @@ class Oauth2Service(
             .awaitFirst()
 
         val requestDto = KISApprovalRequestDto(
-            grantType = "client_credentials",
+            grantType = CLIENT_CREDENTIAL,
             appKey = user.appKey,
             secretKey = user.appSecret)
         return kisOauth2RealClient.postApproval(requestDto).awaitSingle()
@@ -58,7 +59,7 @@ class Oauth2Service(
             .awaitFirst()
 
         val requestDto = KISTokenRequestDto(
-            grantType = "client_credentials",
+            grantType = CLIENT_CREDENTIAL,
             appKey = user.appKey,
             appSecret = user.appSecret)
         val dto = kisOauth2Client.postTokenP(requestDto).awaitSingle()
@@ -76,7 +77,7 @@ class Oauth2Service(
             .awaitFirst()
 
         val requestDto = KISTokenRequestDto(
-            grantType = "client_credentials",
+            grantType = CLIENT_CREDENTIAL,
             appKey = user.appKey,
             appSecret = user.appSecret)
         val dto = kisOauth2RealClient.postTokenP(requestDto).awaitSingle()

--- a/src/test/kotlin/com/knu/mockin/kisclient/KISOauth2ClientTest.kt
+++ b/src/test/kotlin/com/knu/mockin/kisclient/KISOauth2ClientTest.kt
@@ -1,6 +1,8 @@
 package com.knu.mockin.kisclient
 
 import com.knu.mockin.config.ConstantConfig
+import com.knu.mockin.exception.CustomException
+import com.knu.mockin.model.dto.kisrequest.oauth.KISApprovalRequestDto
 import com.knu.mockin.model.dto.kisrequest.oauth.KISTokenRequestDto
 import com.knu.mockin.model.enum.Constant
 import com.knu.mockin.repository.UserRepository
@@ -27,6 +29,16 @@ class KISOauth2ClientTest(
             val dto = kisOauth2Client.postTokenP(requestDto).awaitSingle()
 
             RedisUtil.saveToken(user.email tag Constant.MOCK, dto.accessToken)
+        }
+
+        test("postApproval 테스트"){
+            val requestDto = KISApprovalRequestDto(
+                grantType = "client_credentials",
+                appKey = user!!.appKey,
+                secretKey = user.appSecret)
+            val dto = kisOauth2Client.postApproval(requestDto).awaitSingle()
+            println(dto)
+
         }
     }
 })

--- a/src/test/kotlin/com/knu/mockin/service/AccountServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/AccountServiceTest.kt
@@ -1,9 +1,14 @@
 package com.knu.mockin.service
 
 import com.knu.mockin.dsl.RestDocsUtils
+import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
 import com.knu.mockin.dsl.toDto
+import com.knu.mockin.kisclient.KISOauth2Client
+import com.knu.mockin.kisclient.KISOauth2RealClient
 import com.knu.mockin.model.dto.request.account.KeyPairRequestDto
 import com.knu.mockin.model.dto.request.account.UserAccountNumberRequestDto
+import com.knu.mockin.model.dto.response.AccessTokenAPIResponseDto
+import com.knu.mockin.model.dto.response.ApprovalKeyResponseDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.model.entity.MockKey
 import com.knu.mockin.model.entity.RealKey
@@ -23,16 +28,21 @@ import reactor.core.publisher.Mono
 class AccountServiceTest(
     private val mockKeyRepository: MockKeyRepository = mockk<MockKeyRepository>(),
     private val userRepository: UserRepository = mockk<UserRepository>(),
-    private val realKeyRepository: RealKeyRepository = mockk<RealKeyRepository>()
+    private val realKeyRepository: RealKeyRepository = mockk<RealKeyRepository>(),
+    private val kisOauth2Client: KISOauth2Client = mockk(),
+    private val kisOauth2RealClient: KISOauth2RealClient = mockk()
 ): BehaviorSpec({
     val accountService = AccountService(
         mockKeyRepository = mockKeyRepository,
         realKeyRepository = realKeyRepository,
-        userRepository = userRepository
+        userRepository = userRepository,
+        kisOauth2Client = kisOauth2Client,
+        kisOauth2RealClient = kisOauth2RealClient,
         )
     val redisTemplate = mockk<RedisTemplate<String, String>>()
     RedisUtil.init(redisTemplate)
-    val user = RestDocsUtils.readJsonFile("setting", "user.json") toDto User::class.java
+    val user = readJsonFile("setting", "user.json") toDto User::class.java
+    val token = readJsonFile("/oauth2/mock-token", "responseDto.json") toDto AccessTokenAPIResponseDto::class.java
 
     beforeTest {
         every { userRepository.findByEmail(user.email) } returns Mono.just(user)
@@ -43,8 +53,8 @@ class AccountServiceTest(
         val uri = "$baseUri/userPatch"
 
         Given("적절한 dto가 주어질 때"){
-            val bodyDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto UserAccountNumberRequestDto::class.java
-            val expectedDto = RestDocsUtils.readJsonFile(uri, "responseDto.json") toDto SimpleMessageResponseDto::class.java
+            val bodyDto = readJsonFile(uri, "requestDto.json") toDto UserAccountNumberRequestDto::class.java
+            val expectedDto = readJsonFile(uri, "responseDto.json") toDto SimpleMessageResponseDto::class.java
 
             When("사용자 계좌번호를 정상적으로 등록한 후"){
                 every { userRepository.updateByEmail(user.email, bodyDto.accountNumber) } returns Mono.just(user)
@@ -61,14 +71,15 @@ class AccountServiceTest(
         val uri = "$baseUri/mock-key"
 
         Given("적절한 dto가 주어질 때"){
-            val bodyDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto KeyPairRequestDto::class.java
-            val expectedDto = RestDocsUtils.readJsonFile(uri, "responseDto.json") toDto SimpleMessageResponseDto::class.java
+            val bodyDto = readJsonFile(uri, "requestDto.json") toDto KeyPairRequestDto::class.java
+            val expectedDto = readJsonFile(uri, "responseDto.json") toDto SimpleMessageResponseDto::class.java
             val mockKey = MockKey(user.email, bodyDto.appKey, bodyDto.appSecret)
 
-            When("모의투자 키 페어를 db에 저장한 후"){
+            When("모의투자 키의 유효성을 검증한 후 적절하면"){
+                every { kisOauth2Client.postTokenP(any()) } returns Mono.just(token)
                 every { mockKeyRepository.save(mockKey) } returns Mono.just(mockKey)
 
-                Then("응답 DTO를 정상적으로 받아야 한다."){
+                Then("db에 저장하고 응답 DTO를 정상적으로 받아야 한다."){
                     val result = accountService.postMockKeyPair(bodyDto, user.email)
                     result shouldBe expectedDto
                 }
@@ -80,14 +91,15 @@ class AccountServiceTest(
         val uri = "$baseUri/real-key"
 
         Given("적절한 dto가 주어질 때"){
-            val bodyDto = RestDocsUtils.readJsonFile(uri, "requestDto.json") toDto KeyPairRequestDto::class.java
-            val expectedDto = RestDocsUtils.readJsonFile(uri, "responseDto.json") toDto SimpleMessageResponseDto::class.java
+            val bodyDto = readJsonFile(uri, "requestDto.json") toDto KeyPairRequestDto::class.java
+            val expectedDto = readJsonFile(uri, "responseDto.json") toDto SimpleMessageResponseDto::class.java
             val realKey = RealKey(user.email, bodyDto.appKey, bodyDto.appSecret)
 
-            When("모의투자 키 페어를 db에 저장한 후"){
+            When("실전투자 키의 유효성을 검증한 후 적절하면"){
+                every { kisOauth2RealClient.postTokenP(any()) } returns Mono.just(token)
                 every { realKeyRepository.save(realKey) } returns Mono.just(realKey)
 
-                Then("응답 DTO를 정상적으로 받아야 한다."){
+                Then("db에 저장하고 응답 DTO를 정상적으로 받아야 한다."){
                     val result = accountService.postRealKeyPair(bodyDto, user.email)
                     result shouldBe expectedDto
                 }


### PR DESCRIPTION
## **PR**

### 작업 내용

- 모의 키 등록 시 유효성 검증 추가
- 실전 키 등록 시 유효성 검증 추가
- "client credentials"에 대한 상수 추가
- 테스트 코드 변경

---
### 참고 사항

계좌번호에 대한 검증은 등록 시에는 확인할 수 있는 방법이 당장에는 없습니다.
대신 계좌번호를 필요로 하는 API 호출 시 
502 에러와 함께 "ERROR : INPUT INVALID_CHECK_ACNO" 메세지를 보내므로 확인은 가능합니다.

만약 등록 시 계좌번호 검증을 하고 싶다면,
해당 계좌번호로 1원과 함께 랜덤한 4자리 숫자를 보내어
입력 받아 확인하는 API를 추가한다면 검증이 가능하지 않을까 싶네요.

---
### ✏ Git Close
#152 
