### PR TITLE
Feat/issue #156

### DIFF
--- a/src/main/kotlin/com/knu/mockin/kisclient/KISTradingClient.kt
+++ b/src/main/kotlin/com/knu/mockin/kisclient/KISTradingClient.kt
@@ -99,7 +99,7 @@ class KISTradingClient(
         headerDto: KISOverSeaRequestHeaderDto,
         parameterDto: KISPresentBalanceRequestParameterDto
     ): Mono<KISPresentBalanceResponseDto>{
-        val targetUri = buildUri("${tradingUrl}/inquire-psamount", parameterDto)
+        val targetUri = buildUri("${tradingUrl}/inquire-present-balance", parameterDto)
 
         return webClientMock.getWithParams(
             uri = targetUri,

--- a/src/main/kotlin/com/knu/mockin/model/enum/Constant.kt
+++ b/src/main/kotlin/com/knu/mockin/model/enum/Constant.kt
@@ -6,3 +6,13 @@ object Constant {
     const val MOCK: String = "mock"
     const val CLIENT_CREDENTIAL: String = "client_credentials"
 }
+
+object TimeConstant{
+    const val FIFTEEN_MINUTES = 15L
+    const val THIRTY_MINUTES: Long = 30L
+    const val ONE_HOUR: Long = 60L
+    const val THREE_HOURS: Long = 180L
+    const val SIX_HOURS: Long = 360L
+    const val TWELVE_HOURS: Long = 720L
+    const val ONE_DAY: Long = 1440L
+}

--- a/src/main/kotlin/com/knu/mockin/service/TradingService.kt
+++ b/src/main/kotlin/com/knu/mockin/service/TradingService.kt
@@ -91,7 +91,7 @@ class TradingService(
         val response = kisTradingClient
             .getNCCS(headerDto, kisnccsRequestParameterDto)
             .awaitSingle()
-        RedisUtil.setData(redisCacheKey, response, THIRTY_MINUTES)
+        RedisUtil.setData(redisCacheKey, response, ONE_DAY)
 
         return response
     }

--- a/src/main/kotlin/com/knu/mockin/util/ExtensionUtil.kt
+++ b/src/main/kotlin/com/knu/mockin/util/ExtensionUtil.kt
@@ -1,11 +1,18 @@
 package com.knu.mockin.util
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.knu.mockin.exception.CustomException
 import com.knu.mockin.exception.ErrorCode
 import reactor.core.publisher.Mono
 
 object ExtensionUtil {
+    private val objectMapper = jacksonObjectMapper()
+
     fun <T> Mono<T>.orThrow(errorCode: ErrorCode): Mono<T> {
         return this.switchIfEmpty(Mono.error(CustomException(errorCode)))
+    }
+
+    infix fun <T> String.toDto(dto: Class<T>): T {
+        return objectMapper.readValue(this, dto)
     }
 }

--- a/src/main/kotlin/com/knu/mockin/util/RedisUtil.kt
+++ b/src/main/kotlin/com/knu/mockin/util/RedisUtil.kt
@@ -1,8 +1,10 @@
 package com.knu.mockin.util
 
+import com.knu.mockin.logging.utils.LogUtil.toJson
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 
 @Component
 object RedisUtil{
@@ -23,12 +25,21 @@ object RedisUtil{
     fun saveEmailCode(email: String,
                       token: String,
                       timeout: Long,
-                      unit: java.util.concurrent.TimeUnit) {
+                      unit: TimeUnit) {
         return redisTemplate.opsForValue().set(email, token, timeout, unit)
     }
 
 
     fun removeToken(email: String) {
         redisTemplate.delete(email)
+    }
+
+
+    fun <T> setData(key: String, value: T, expiration: Long) {
+        redisTemplate.opsForValue().set(key, toJson(value), expiration, TimeUnit.MINUTES)
+    }
+
+    fun getData(key: String): String? {
+        return redisTemplate.opsForValue().get(key)
     }
 }

--- a/src/main/kotlin/com/knu/mockin/util/RedisUtil.kt
+++ b/src/main/kotlin/com/knu/mockin/util/RedisUtil.kt
@@ -42,4 +42,8 @@ object RedisUtil{
     fun getData(key: String): String? {
         return redisTemplate.opsForValue().get(key)
     }
+
+    fun deleteData(key: String) {
+        redisTemplate.delete(key)
+    }
 }

--- a/src/main/kotlin/com/knu/mockin/util/RedisUtil.kt
+++ b/src/main/kotlin/com/knu/mockin/util/RedisUtil.kt
@@ -43,7 +43,7 @@ object RedisUtil{
         return redisTemplate.opsForValue().get(key)
     }
 
-    fun deleteData(key: String) {
-        redisTemplate.delete(key)
+    fun deleteData(key: String): Boolean {
+        return redisTemplate.delete(key)
     }
 }

--- a/src/test/kotlin/com/knu/mockin/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/AccountControllerTest.kt
@@ -3,13 +3,13 @@ package com.knu.mockin.controller
 import com.knu.mockin.controller.util.*
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
 import com.knu.mockin.dsl.RestDocsUtils.toBody
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.model.entity.User
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.JwtUtil
 import com.knu.mockin.security.SecurityTestConfig
 import com.knu.mockin.service.AccountService
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.spring.SpringExtension

--- a/src/test/kotlin/com/knu/mockin/controller/HealthCheckControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/HealthCheckControllerTest.kt
@@ -1,19 +1,17 @@
 package com.knu.mockin.controller
 
 import com.knu.mockin.controller.util.*
-import com.knu.mockin.dsl.RestDocsUtils
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
 import com.knu.mockin.dsl.RestDocsUtils.toBody
 import com.knu.mockin.dsl.RestDocsUtils.toPairs
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.dto.request.account.UserAccountNumberRequestDto
-import com.knu.mockin.model.dto.request.trading.NCCSRequestParameterDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.model.entity.User
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.JwtUtil
 import com.knu.mockin.security.SecurityTestConfig
 import com.knu.mockin.service.HealthCheckService
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.coEvery

--- a/src/test/kotlin/com/knu/mockin/controller/LoginControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/LoginControllerTest.kt
@@ -3,7 +3,6 @@
     import com.knu.mockin.controller.util.*
     import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
     import com.knu.mockin.dsl.RestDocsUtils.toBody
-    import com.knu.mockin.dsl.toDto
     import com.knu.mockin.model.dto.request.login.Jwt
     import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
     import com.knu.mockin.model.entity.User
@@ -12,6 +11,7 @@
     import com.knu.mockin.security.SecurityTestConfig
     import com.knu.mockin.service.login.EmailService
     import com.knu.mockin.service.login.UserService
+    import com.knu.mockin.util.ExtensionUtil.toDto
     import com.ninjasquad.springmockk.MockkBean
     import io.kotest.core.spec.style.StringSpec
     import io.kotest.extensions.spring.SpringExtension

--- a/src/test/kotlin/com/knu/mockin/controller/Oauth2ControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/Oauth2ControllerTest.kt
@@ -3,7 +3,6 @@ package com.knu.mockin.controller
 import com.knu.mockin.controller.util.*
 import com.knu.mockin.dsl.RestDocsUtils
 import com.knu.mockin.dsl.RestDocsUtils.toBody
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.dto.response.AccessTokenAPIResponseDto
 import com.knu.mockin.model.dto.response.ApprovalKeyResponseDto
 import com.knu.mockin.model.entity.User
@@ -11,6 +10,7 @@ import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.JwtUtil
 import com.knu.mockin.security.SecurityTestConfig
 import com.knu.mockin.service.Oauth2Service
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.coEvery

--- a/src/test/kotlin/com/knu/mockin/controller/TradingControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/TradingControllerTest.kt
@@ -4,7 +4,6 @@ import com.knu.mockin.controller.util.*
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
 import com.knu.mockin.dsl.RestDocsUtils.toBody
 import com.knu.mockin.dsl.RestDocsUtils.toPairs
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.dto.kisresponse.trading.*
 import com.knu.mockin.model.dto.request.trading.*
 import com.knu.mockin.model.entity.User
@@ -12,6 +11,7 @@ import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.JwtUtil
 import com.knu.mockin.security.SecurityTestConfig
 import com.knu.mockin.service.TradingService
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.coEvery

--- a/src/test/kotlin/com/knu/mockin/controller/quotations/analysis/real/AnalysisRealControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/quotations/analysis/real/AnalysisRealControllerTest.kt
@@ -1,23 +1,18 @@
 package com.knu.mockin.controller.quotations.analysis.real
 
 import com.knu.mockin.controller.quotations.analysis.AnalysisRealController
-import com.knu.mockin.controller.quotations.basic.BasicRealController
-import com.knu.mockin.controller.quotations.basic.real.BasicRealControllerTest
 import com.knu.mockin.controller.util.*
 import com.knu.mockin.dsl.RestDocsUtils
 import com.knu.mockin.dsl.RestDocsUtils.toBody
 import com.knu.mockin.dsl.RestDocsUtils.toPairs
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.dto.kisresponse.quotations.analysis.KISNewsTitleResponseDto
-import com.knu.mockin.model.dto.kisresponse.quotations.basic.real.KISCountriesHolidayResponseDto
 import com.knu.mockin.model.dto.request.quotations.analysis.real.NewsTitleRequestParameterDto
-import com.knu.mockin.model.dto.request.quotations.basic.real.CountriesHolidayRequestParameterDto
 import com.knu.mockin.model.entity.User
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.JwtUtil
 import com.knu.mockin.security.SecurityTestConfig
 import com.knu.mockin.service.quotations.analysis.AnalysisRealService
-import com.knu.mockin.service.quotations.basic.real.BasicRealService
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.coEvery

--- a/src/test/kotlin/com/knu/mockin/controller/quotations/basic/mock/BasicControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/quotations/basic/mock/BasicControllerTest.kt
@@ -5,7 +5,6 @@ import com.knu.mockin.controller.util.*
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
 import com.knu.mockin.dsl.RestDocsUtils.toBody
 import com.knu.mockin.dsl.RestDocsUtils.toPairs
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.dto.kisresponse.quotations.basic.mock.*
 import com.knu.mockin.model.dto.request.quotations.basic.mock.*
 import com.knu.mockin.service.quotations.basic.mock.BasicService
@@ -13,6 +12,7 @@ import com.knu.mockin.model.entity.User
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.JwtUtil
 import com.knu.mockin.security.SecurityTestConfig
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.coEvery

--- a/src/test/kotlin/com/knu/mockin/controller/quotations/basic/real/BasicRealControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/quotations/basic/real/BasicRealControllerTest.kt
@@ -8,11 +8,11 @@ import com.knu.mockin.dsl.RestDocsUtils.toPairs
 import com.knu.mockin.model.dto.kisresponse.quotations.basic.real.*
 import com.knu.mockin.model.dto.request.quotations.basic.real.*
 import com.knu.mockin.service.quotations.basic.real.BasicRealService
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.entity.User
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.JwtUtil
 import com.knu.mockin.security.SecurityTestConfig
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.coEvery

--- a/src/test/kotlin/com/knu/mockin/dsl/InfixFunctions.kt
+++ b/src/test/kotlin/com/knu/mockin/dsl/InfixFunctions.kt
@@ -1,10 +1,11 @@
 package com.knu.mockin.dsl
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.knu.mockin.model.DocsFieldType
 import com.knu.mockin.model.Field
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
+
 
 infix fun <T> T.means(description: String): Pair<T, String> {
     return Pair(this, description)
@@ -12,11 +13,6 @@ infix fun <T> T.means(description: String): Pair<T, String> {
 
 infix fun String.type(docsFieldType: DocsFieldType): Field {
     return createField(this, docsFieldType.type)
-}
-
-infix fun <T> String.toDto(dto: Class<T>): T {
-    val objectMapper = ObjectMapper()
-    return objectMapper.readValue(this, dto)
 }
 
 private fun createField(value: String, type: JsonFieldType): Field {

--- a/src/test/kotlin/com/knu/mockin/kisclient/KISOauth2ClientTest.kt
+++ b/src/test/kotlin/com/knu/mockin/kisclient/KISOauth2ClientTest.kt
@@ -1,7 +1,6 @@
 package com.knu.mockin.kisclient
 
 import com.knu.mockin.config.ConstantConfig
-import com.knu.mockin.exception.CustomException
 import com.knu.mockin.model.dto.kisrequest.oauth.KISApprovalRequestDto
 import com.knu.mockin.model.dto.kisrequest.oauth.KISTokenRequestDto
 import com.knu.mockin.model.enum.Constant

--- a/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
+++ b/src/test/kotlin/com/knu/mockin/kisclient/KISTradingClientTest.kt
@@ -2,13 +2,13 @@ package com.knu.mockin.kisclient
 
 import com.knu.mockin.config.ConstantConfig
 import com.knu.mockin.dsl.RestDocsUtils
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.exception.CustomException
 import com.knu.mockin.exception.ErrorCode
 import com.knu.mockin.model.dto.request.trading.*
 import com.knu.mockin.model.enum.TradeId
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.service.util.ServiceUtil
+import com.knu.mockin.util.ExtensionUtil.toDto
 import io.kotest.core.spec.style.FunSpec
 import org.reactivestreams.Publisher
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/com/knu/mockin/service/AccountServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/AccountServiceTest.kt
@@ -1,14 +1,11 @@
 package com.knu.mockin.service
 
-import com.knu.mockin.dsl.RestDocsUtils
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.kisclient.KISOauth2Client
 import com.knu.mockin.kisclient.KISOauth2RealClient
 import com.knu.mockin.model.dto.request.account.KeyPairRequestDto
 import com.knu.mockin.model.dto.request.account.UserAccountNumberRequestDto
 import com.knu.mockin.model.dto.response.AccessTokenAPIResponseDto
-import com.knu.mockin.model.dto.response.ApprovalKeyResponseDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.model.entity.MockKey
 import com.knu.mockin.model.entity.RealKey
@@ -16,6 +13,7 @@ import com.knu.mockin.model.entity.User
 import com.knu.mockin.repository.MockKeyRepository
 import com.knu.mockin.repository.RealKeyRepository
 import com.knu.mockin.repository.UserRepository
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.knu.mockin.util.RedisUtil
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/knu/mockin/service/HealthCheckTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/HealthCheckTest.kt
@@ -1,8 +1,8 @@
 package com.knu.mockin.service
 
 import com.knu.mockin.dsl.RestDocsUtils
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
+import com.knu.mockin.util.ExtensionUtil.toDto
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 

--- a/src/test/kotlin/com/knu/mockin/service/Oauth2ServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/Oauth2ServiceTest.kt
@@ -1,7 +1,6 @@
 package com.knu.mockin.service
 
 import com.knu.mockin.dsl.RestDocsUtils
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.kisclient.KISOauth2Client
 import com.knu.mockin.kisclient.KISOauth2RealClient
 import com.knu.mockin.model.dto.kisrequest.oauth.KISApprovalRequestDto
@@ -12,6 +11,7 @@ import com.knu.mockin.model.entity.UserWithKeyPair
 import com.knu.mockin.model.enum.Constant.MOCK
 import com.knu.mockin.model.enum.Constant.REAL
 import com.knu.mockin.repository.UserRepository
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.knu.mockin.util.RedisUtil
 import com.knu.mockin.util.tag
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/com/knu/mockin/service/login/EmailServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/login/EmailServiceTest.kt
@@ -1,12 +1,12 @@
 package com.knu.mockin.service.login
 
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.exception.CustomException
 import com.knu.mockin.exception.ErrorCode
 import com.knu.mockin.model.dto.request.login.EmailCheckRequestDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.model.entity.User
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.knu.mockin.util.RedisUtil
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/com/knu/mockin/service/login/UserServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/login/UserServiceTest.kt
@@ -1,7 +1,6 @@
 package com.knu.mockin.service.login
 
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.exception.CustomException
 import com.knu.mockin.exception.ErrorCode
 import com.knu.mockin.model.dto.request.login.Jwt
@@ -12,6 +11,7 @@ import com.knu.mockin.model.entity.User
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.BearerToken
 import com.knu.mockin.security.JwtUtil
+import com.knu.mockin.util.ExtensionUtil.toDto
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/knu/mockin/service/quotations/analysis/AnalysisRealServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/quotations/analysis/AnalysisRealServiceTest.kt
@@ -1,19 +1,16 @@
 package com.knu.mockin.service.quotations.analysis
 
 import com.knu.mockin.dsl.RestDocsUtils
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.kisclient.quotations.analysis.KISAnalysisRealClient
 import com.knu.mockin.model.dto.kisresponse.quotations.analysis.KISNewsTitleResponseDto
-import com.knu.mockin.model.dto.kisresponse.quotations.basic.real.KISCountriesHolidayResponseDto
 import com.knu.mockin.model.dto.request.quotations.analysis.real.NewsTitleRequestParameterDto
 import com.knu.mockin.model.dto.request.quotations.analysis.real.asDomain
-import com.knu.mockin.model.dto.request.quotations.basic.real.CountriesHolidayRequestParameterDto
 import com.knu.mockin.model.dto.request.quotations.basic.real.asDomain
 import com.knu.mockin.model.entity.UserWithKeyPair
 import com.knu.mockin.model.enum.TradeId
 import com.knu.mockin.repository.UserRepository
-import com.knu.mockin.service.quotations.basic.real.BasicRealService
 import com.knu.mockin.service.util.ServiceUtil
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.knu.mockin.util.RedisUtil
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/knu/mockin/service/quotations/basic/BasicRealServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/quotations/basic/BasicRealServiceTest.kt
@@ -1,7 +1,6 @@
 package com.knu.mockin.service.quotations.basic
 
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.kisclient.quotations.basic.KISBasicRealClient
 import com.knu.mockin.model.dto.kisresponse.quotations.basic.real.*
 import com.knu.mockin.model.dto.request.quotations.basic.real.*
@@ -10,6 +9,7 @@ import com.knu.mockin.model.enum.TradeId
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.service.quotations.basic.real.BasicRealService
 import com.knu.mockin.service.util.ServiceUtil.createHeader
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.knu.mockin.util.RedisUtil
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/knu/mockin/service/quotations/basic/BasicServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/quotations/basic/BasicServiceTest.kt
@@ -1,7 +1,6 @@
 package com.knu.mockin.service.quotations.basic
 
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
-import com.knu.mockin.dsl.toDto
 import com.knu.mockin.kisclient.quotations.basic.KISBasicClient
 import com.knu.mockin.model.dto.kisresponse.quotations.basic.mock.*
 import com.knu.mockin.model.dto.request.quotations.basic.mock.*
@@ -10,6 +9,7 @@ import com.knu.mockin.model.enum.TradeId
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.service.quotations.basic.mock.BasicService
 import com.knu.mockin.service.util.ServiceUtil.createHeader
+import com.knu.mockin.util.ExtensionUtil.toDto
 import com.knu.mockin.util.RedisUtil
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
## **PR**

### 작업 내용

- RedisUtil에 캐싱을 위한 함수 추가
- TradingService에 캐싱 적용
- TradingService 테스트 코드 작성
- 기타 오류 수정

---
### 참고 사항

체결내역(CCNL), 미체결내역(NCCS), 체결기준현재잔고(Present Balance)의 경우,
주문(Order) 또는 주문 취소(Order Reverse) 시 값이 변경되므로 redis에서 값을 삭제하도록 했습니다.

- 잔고(Balance)의 경우 
주문 체결이 일어나더라도 최소 2일은 지나야 값이 반영되므로
유효시간을 하루로 설정했습니다.

- CCNL, NCCS의 경우 
주문 시에만 값이 바뀌고, 이때에는 redis에서 삭제되므로
유효시간을 하루로 설정했습니다.

- Present Balance의 경우
주문 이후 체결이 언제 완료될 지 모르는 관계로
상대적으로 짧은 30분으로 설정했습니다.

- Psamount의 경우
현재 가진 돈에 따라 매번 값이 변해야 하므로
캐싱의 가치가 없다고 판단했고
캐싱을 적용하지 않았습니다.

infix 함수의 toDto가 테스트 뿐만 아니라 메인 코드에서도 활용되어 메인 쪽 util로 옮기고, 
유지 보수 용이를 위해 test에 있는 toDto 삭제 진행했습니다.
-> 모든 테스트 코드에 있는 toDto의 import 부분 수정진행했습니다.

---
### ✏ Git Close
#156 