### PR TITLE
Feat/issue #185

### DIFF
--- a/src/main/kotlin/com/knu/mockin/controller/LoginController.kt
+++ b/src/main/kotlin/com/knu/mockin/controller/LoginController.kt
@@ -1,6 +1,7 @@
 package com.knu.mockin.controller
 
 import com.knu.mockin.model.dto.request.login.*
+import com.knu.mockin.model.dto.response.LoginResponseDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.service.login.EmailService
 import com.knu.mockin.service.login.UserService
@@ -29,7 +30,7 @@ class LoginController (
     @PostMapping("/login")
     suspend fun login(
         @RequestBody loginRequestDto: LoginRequestDto
-    ): ResponseEntity<Jwt> {
+    ): ResponseEntity<LoginResponseDto> {
         val result = userService.loginUser(loginRequestDto)
 
         return ResponseEntity.ok(result)
@@ -56,7 +57,7 @@ class LoginController (
     @PostMapping("validate-token")
     suspend fun validateToken(
         @RequestBody requestDto: TokenValidationRequestDto
-    ): ResponseEntity<Jwt> {
+    ): ResponseEntity<LoginResponseDto> {
         val result = userService.validateToken(requestDto)
 
         return ResponseEntity.ok(result)

--- a/src/main/kotlin/com/knu/mockin/model/dto/request/login/Jwt.kt
+++ b/src/main/kotlin/com/knu/mockin/model/dto/request/login/Jwt.kt
@@ -1,5 +1,0 @@
-package com.knu.mockin.model.dto.request.login
-
-data class Jwt (
-    val token: String = ""
-)

--- a/src/main/kotlin/com/knu/mockin/model/dto/response/LoginResponseDto.kt
+++ b/src/main/kotlin/com/knu/mockin/model/dto/response/LoginResponseDto.kt
@@ -1,0 +1,5 @@
+package com.knu.mockin.model.dto.response
+
+data class LoginResponseDto (
+    val token: String = ""
+)

--- a/src/main/kotlin/com/knu/mockin/model/dto/response/LoginResponseDto.kt
+++ b/src/main/kotlin/com/knu/mockin/model/dto/response/LoginResponseDto.kt
@@ -1,5 +1,19 @@
 package com.knu.mockin.model.dto.response
 
+import com.knu.mockin.model.entity.UserInfo
+
 data class LoginResponseDto (
-    val token: String = ""
+    val token: String = "",
+    val accountNumber:String = "",
+    val isMockRegistered: Boolean,
+    val isRealRegistered: Boolean
 )
+
+fun buildLoginResponseDto(token: String, userInfo:UserInfo): LoginResponseDto {
+    return LoginResponseDto(
+        token = token,
+        accountNumber = userInfo.accountNumber,
+        isMockRegistered = userInfo.appKey != "",
+        isRealRegistered = userInfo.appSecret != ""
+    )
+}

--- a/src/main/kotlin/com/knu/mockin/model/entity/UserWithKeyPair.kt
+++ b/src/main/kotlin/com/knu/mockin/model/entity/UserWithKeyPair.kt
@@ -6,3 +6,11 @@ data class UserWithKeyPair(
     val appKey: String = "",
     val appSecret: String = ""
 )
+
+data class UserInfo(
+    val email: String = "",
+    val password: String = "",
+    val accountNumber: String = "",
+    val appKey: String = "",
+    val appSecret: String = ""
+)

--- a/src/main/kotlin/com/knu/mockin/service/AccountService.kt
+++ b/src/main/kotlin/com/knu/mockin/service/AccountService.kt
@@ -1,6 +1,5 @@
 package com.knu.mockin.service
 
-import com.knu.mockin.exception.ErrorCode
 import com.knu.mockin.kisclient.KISOauth2Client
 import com.knu.mockin.kisclient.KISOauth2RealClient
 import com.knu.mockin.model.dto.kisrequest.oauth.KISTokenRequestDto
@@ -13,8 +12,6 @@ import com.knu.mockin.model.enum.Constant.CLIENT_CREDENTIAL
 import com.knu.mockin.repository.MockKeyRepository
 import com.knu.mockin.repository.RealKeyRepository
 import com.knu.mockin.repository.UserRepository
-import com.knu.mockin.util.ExtensionUtil.orThrow
-import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/knu/mockin/service/login/UserService.kt
+++ b/src/main/kotlin/com/knu/mockin/service/login/UserService.kt
@@ -2,7 +2,7 @@ package com.knu.mockin.service.login
 
 import com.knu.mockin.exception.CustomException
 import com.knu.mockin.exception.ErrorCode
-import com.knu.mockin.model.dto.request.login.Jwt
+import com.knu.mockin.model.dto.response.LoginResponseDto
 import com.knu.mockin.model.dto.request.login.LoginRequestDto
 import com.knu.mockin.model.dto.request.login.SignupRequestDto
 import com.knu.mockin.model.dto.request.login.TokenValidationRequestDto
@@ -46,7 +46,7 @@ class UserService(
         return SimpleMessageResponseDto("회원가입이 완료되었습니다!")
     }
 
-    suspend fun loginUser(loginRequestDto: LoginRequestDto): Jwt {
+    suspend fun loginUser(loginRequestDto: LoginRequestDto): LoginResponseDto {
         val user = userRepository.findByEmail(loginRequestDto.email).awaitSingleOrNull()
 
         user?.let {
@@ -54,10 +54,10 @@ class UserService(
                 val storedToken = RedisUtil.getToken(user.email tag JWT)
 
                 if (storedToken != null) {
-                    return Jwt(BearerToken(storedToken).value)
+                    return LoginResponseDto(BearerToken(storedToken).value)
                 }
 
-                return Jwt(jwtUtil.generate(it.email).value)
+                return LoginResponseDto(jwtUtil.generate(it.email).value)
             }
         }
 
@@ -66,11 +66,11 @@ class UserService(
 
     suspend fun validateToken(
         requestDto: TokenValidationRequestDto
-    ): Jwt {
+    ): LoginResponseDto {
         val storedToken = RedisUtil.getToken(requestDto.email tag JWT)
 
         if (requestDto.token == storedToken) {
-            return Jwt(jwtUtil.generate(requestDto.email).value)
+            return LoginResponseDto(jwtUtil.generate(requestDto.email).value)
         }
 
         throw CustomException(ErrorCode.TOKEN_EXPIRED)

--- a/src/main/kotlin/com/knu/mockin/service/quotations/basic/mock/BasicService.kt
+++ b/src/main/kotlin/com/knu/mockin/service/quotations/basic/mock/BasicService.kt
@@ -2,15 +2,16 @@ package com.knu.mockin.service.quotations.basic.mock
 
 import com.knu.mockin.exception.ErrorCode
 import com.knu.mockin.kisclient.quotations.basic.KISBasicClient
-import com.knu.mockin.model.dto.kisheader.request.KISOverSeaRequestHeaderDto
-import com.knu.mockin.model.dto.kisresponse.quotations.basic.mock.*
+import com.knu.mockin.model.dto.kisresponse.quotations.basic.mock.KISDailyPriceResponseDto
+import com.knu.mockin.model.dto.kisresponse.quotations.basic.mock.KISInquireDailyChartPriceResponseDto
+import com.knu.mockin.model.dto.kisresponse.quotations.basic.mock.KISInquireSearchResponseDto
+import com.knu.mockin.model.dto.kisresponse.quotations.basic.mock.KISPriceResponseDto
 import com.knu.mockin.model.dto.request.quotations.basic.mock.*
-import com.knu.mockin.model.enum.Constant.MOCK
 import com.knu.mockin.model.enum.TimeConstant.FIFTEEN_MINUTES
 import com.knu.mockin.model.enum.TimeConstant.ONE_MINUTE
-import com.knu.mockin.model.enum.TimeConstant.THIRTY_MINUTES
 import com.knu.mockin.model.enum.TradeId
 import com.knu.mockin.repository.UserRepository
+import com.knu.mockin.service.util.ServiceUtil.createHeader
 import com.knu.mockin.util.ExtensionUtil.orThrow
 import com.knu.mockin.util.ExtensionUtil.toDto
 import com.knu.mockin.util.RedisUtil
@@ -18,7 +19,6 @@ import com.knu.mockin.util.tag
 import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.stereotype.Service
-import com.knu.mockin.service.util.ServiceUtil.createHeader
 
 @Service
 class BasicService(

--- a/src/main/kotlin/com/knu/mockin/service/quotations/basic/real/BasicRealService.kt
+++ b/src/main/kotlin/com/knu/mockin/service/quotations/basic/real/BasicRealService.kt
@@ -2,10 +2,8 @@ package com.knu.mockin.service.quotations.basic.real
 
 import com.knu.mockin.exception.ErrorCode
 import com.knu.mockin.kisclient.quotations.basic.KISBasicRealClient
-import com.knu.mockin.model.dto.kisheader.request.KISOverSeaRequestHeaderDto
 import com.knu.mockin.model.dto.kisresponse.quotations.basic.real.*
 import com.knu.mockin.model.dto.request.quotations.basic.real.*
-import com.knu.mockin.model.enum.Constant.REAL
 import com.knu.mockin.model.enum.TimeConstant.ONE_HOUR
 import com.knu.mockin.model.enum.TimeConstant.ONE_MINUTE
 import com.knu.mockin.model.enum.TimeConstant.TWELVE_HOURS

--- a/src/test/kotlin/com/knu/mockin/aspect/LoggingAspectTest.kt
+++ b/src/test/kotlin/com/knu/mockin/aspect/LoggingAspectTest.kt
@@ -51,7 +51,7 @@ class LoggingAspectTest :BehaviorSpec({
     }
     Context("Login Controller의 메소드에 대해"){
         Given("실행 전후로"){
-            val response = LoginResponseDto("access token")
+            val response = LoginResponseDto("access token", isMockRegistered = true, isRealRegistered =  true)
 
             When("적절한 로그를 남기고"){
                 every { joinPoint.proceed() } returns Mono.just(response)

--- a/src/test/kotlin/com/knu/mockin/aspect/LoggingAspectTest.kt
+++ b/src/test/kotlin/com/knu/mockin/aspect/LoggingAspectTest.kt
@@ -1,6 +1,6 @@
 package com.knu.mockin.aspect
 
-import com.knu.mockin.model.dto.request.login.Jwt
+import com.knu.mockin.model.dto.response.LoginResponseDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.*
@@ -51,7 +51,7 @@ class LoggingAspectTest :BehaviorSpec({
     }
     Context("Login Controller의 메소드에 대해"){
         Given("실행 전후로"){
-            val response = Jwt("access token")
+            val response = LoginResponseDto("access token")
 
             When("적절한 로그를 남기고"){
                 every { joinPoint.proceed() } returns Mono.just(response)

--- a/src/test/kotlin/com/knu/mockin/controller/LoginControllerTest.kt
+++ b/src/test/kotlin/com/knu/mockin/controller/LoginControllerTest.kt
@@ -3,7 +3,7 @@
     import com.knu.mockin.controller.util.*
     import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
     import com.knu.mockin.dsl.RestDocsUtils.toBody
-    import com.knu.mockin.model.dto.request.login.Jwt
+    import com.knu.mockin.model.dto.response.LoginResponseDto
     import com.knu.mockin.model.dto.request.login.TokenValidationRequestDto
     import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
     import com.knu.mockin.model.entity.User
@@ -90,7 +90,7 @@
         "POST /auth/login" {
             val uri = "${baseUri}/login"
             val requestDto = readJsonFile(uri, "requestDto.json")
-            val expectedDto = readJsonFile(uri, "responseDto.json") toDto Jwt::class.java
+            val expectedDto = readJsonFile(uri, "responseDto.json") toDto LoginResponseDto::class.java
             coEvery { userService.loginUser(any()) } returns expectedDto
 
 
@@ -121,7 +121,7 @@
         "POST /auth/validate-token" {
             val uri = "${baseUri}/validate-token"
             val requestDto = readJsonFile(uri, "requestDto.json")
-            val expectedDto = readJsonFile(uri, "responseDto.json") toDto Jwt::class.java
+            val expectedDto = readJsonFile(uri, "responseDto.json") toDto LoginResponseDto::class.java
             coEvery { userService.validateToken(requestDto toDto TokenValidationRequestDto::class.java) } returns expectedDto
 
             val response = webTestClient.postWithBody(uri, requestDto, expectedDto)

--- a/src/test/kotlin/com/knu/mockin/dsl/RestDocsUtils.kt
+++ b/src/test/kotlin/com/knu/mockin/dsl/RestDocsUtils.kt
@@ -44,6 +44,9 @@ object RestDocsUtils {
                 if(fieldName in listOf("expire_in")){
                     fieldDescriptions.add(fieldName type NUMBER means jsonNode[fieldName].asText())
                 }
+                else if(fieldName.contains("Registered")){
+                    fieldDescriptions.add(fieldName type BOOLEAN means jsonNode[fieldName].asText())
+                }
                 else fieldDescriptions.add(fieldName type STRING means jsonNode[fieldName].asText())
             }
         }

--- a/src/test/kotlin/com/knu/mockin/service/login/UserServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/login/UserServiceTest.kt
@@ -3,7 +3,7 @@ package com.knu.mockin.service.login
 import com.knu.mockin.dsl.RestDocsUtils.readJsonFile
 import com.knu.mockin.exception.CustomException
 import com.knu.mockin.exception.ErrorCode
-import com.knu.mockin.model.dto.request.login.Jwt
+import com.knu.mockin.model.dto.response.LoginResponseDto
 import com.knu.mockin.model.dto.request.login.LoginRequestDto
 import com.knu.mockin.model.dto.request.login.SignupRequestDto
 import com.knu.mockin.model.dto.request.login.TokenValidationRequestDto
@@ -77,7 +77,7 @@ class UserServiceTest(
 
         Given("적절한 dto가 주어질 때"){
             val bodyDto = readJsonFile(uri, "requestDto.json") toDto LoginRequestDto::class.java
-            val expectedDto = readJsonFile(uri, "responseDto.json") toDto Jwt::class.java
+            val expectedDto = readJsonFile(uri, "responseDto.json") toDto LoginResponseDto::class.java
 
             When("이메일, 패스워드가 적절하고, 토큰이 redis에 없으면"){
                 every { userRepository.findByEmail(bodyDto.email) } returns Mono.just(user)
@@ -141,7 +141,7 @@ class UserServiceTest(
 
         Given("검증할 토큰이 올바른 경우"){
             val bodyDto = readJsonFile(uri, "requestDto.json") toDto TokenValidationRequestDto::class.java
-            val expectedDto = readJsonFile(uri, "responseDto.json") toDto Jwt::class.java
+            val expectedDto = readJsonFile(uri, "responseDto.json") toDto LoginResponseDto::class.java
 
             When("redis에 있는 토큰과 같은 지 검증하고"){
                 every { RedisUtil.getToken(bodyDto.email tag JWT) } returns bodyDto.token

--- a/src/test/kotlin/com/knu/mockin/service/login/UserServiceTest.kt
+++ b/src/test/kotlin/com/knu/mockin/service/login/UserServiceTest.kt
@@ -9,6 +9,7 @@ import com.knu.mockin.model.dto.request.login.SignupRequestDto
 import com.knu.mockin.model.dto.request.login.TokenValidationRequestDto
 import com.knu.mockin.model.dto.response.SimpleMessageResponseDto
 import com.knu.mockin.model.entity.User
+import com.knu.mockin.model.entity.UserInfo
 import com.knu.mockin.model.enum.Constant.JWT
 import com.knu.mockin.repository.UserRepository
 import com.knu.mockin.security.BearerToken
@@ -32,6 +33,7 @@ class UserServiceTest(
 ) :BehaviorSpec({
     val userService = UserService(encoder, jwtUtil, userRepository)
     val user = readJsonFile("setting", "user.json") toDto User::class.java
+    val userInfo = readJsonFile("setting", "userInfo.json") toDto UserInfo::class.java
 
     val redisTemplate = mockk<RedisTemplate<String, String>>()
     RedisUtil.init(redisTemplate)
@@ -80,23 +82,23 @@ class UserServiceTest(
             val expectedDto = readJsonFile(uri, "responseDto.json") toDto LoginResponseDto::class.java
 
             When("이메일, 패스워드가 적절하고, 토큰이 redis에 없으면"){
-                every { userRepository.findByEmail(bodyDto.email) } returns Mono.just(user)
+                every { userRepository.findUserInfoByEmail(bodyDto.email) } returns Mono.just(userInfo)
                 every { encoder.matches(any(), any()) } returns true
                 every { RedisUtil.getToken(bodyDto.email tag JWT) } returns null
                 every { jwtUtil.generate(user.email) } returns BearerToken(expectedDto.token)
 
-                Then("JWT 토큰이 담긴 Dto를 정상적으로 받아야 한다."){
+                Then("토큰과 회원 정보가 담긴 Dto를 정상적으로 받아야 한다."){
                     val result = userService.loginUser(bodyDto)
                     result shouldBe expectedDto
                 }
             }
 
             When("이메일, 패스워드가 적절하고, 토큰이 redis에 있으면"){
-                every { userRepository.findByEmail(bodyDto.email) } returns Mono.just(user)
+                every { userRepository.findUserInfoByEmail(bodyDto.email) } returns Mono.just(userInfo)
                 every { encoder.matches(any(), any()) } returns true
                 every { RedisUtil.getToken(bodyDto.email tag JWT) } returns expectedDto.token
 
-                Then("JWT 토큰이 담긴 Dto를 정상적으로 받아야 한다."){
+                Then("토큰과 회원 정보가 담긴 Dto를 정상적으로 받아야 한다."){
                     val result = userService.loginUser(bodyDto)
 
                     result shouldBe expectedDto
@@ -108,7 +110,7 @@ class UserServiceTest(
             val bodyDto = readJsonFile(uri, "requestDto.json") toDto LoginRequestDto::class.java
 
             When("요청 dto의 패스워드가 db에 등록된 것과 다르면"){
-                every { userRepository.findByEmail(bodyDto.email) } returns Mono.just(user)
+                every { userRepository.findUserInfoByEmail(bodyDto.email) } returns Mono.just(userInfo)
                 every { encoder.matches(any(), any()) } returns false
 
                 Then("INVALID_LOGIN 에러를 받아야 한다."){
@@ -124,7 +126,7 @@ class UserServiceTest(
             val bodyDto = readJsonFile(uri, "requestDto.json") toDto LoginRequestDto::class.java
 
             When("사용자가 존재하지 않으면"){
-                every { userRepository.findByEmail(bodyDto.email) } returns Mono.justOrEmpty(null)
+                every { userRepository.findUserInfoByEmail(bodyDto.email) } returns Mono.justOrEmpty(null)
 
                 Then("INVALID_LOGIN 에러를 받아야 한다."){
                     val result = shouldThrowExactly<CustomException> {
@@ -144,10 +146,11 @@ class UserServiceTest(
             val expectedDto = readJsonFile(uri, "responseDto.json") toDto LoginResponseDto::class.java
 
             When("redis에 있는 토큰과 같은 지 검증하고"){
+                every { userRepository.findUserInfoByEmail(bodyDto.email) } returns Mono.just(userInfo)
                 every { RedisUtil.getToken(bodyDto.email tag JWT) } returns bodyDto.token
                 every { jwtUtil.generate(user.email) } returns BearerToken(expectedDto.token)
 
-                Then("같으면, 새로운 토큰을 반환해야 한다."){
+                Then("같으면, 토큰과 회원 정보가 담긴 Dto를 반환해야 한다."){
                     val result = userService.validateToken(bodyDto)
 
                     result shouldBe expectedDto

--- a/src/test/resources/json/auth/login/responseDto.json
+++ b/src/test/resources/json/auth/login/responseDto.json
@@ -1,3 +1,6 @@
 {
-  "token": "jwt-access-token"
+  "token": "jwt-access-token",
+  "accountNumber": "12345678",
+  "isMockRegistered": true,
+  "isRealRegistered": true
 }

--- a/src/test/resources/json/auth/login/responseDtoDescription.json
+++ b/src/test/resources/json/auth/login/responseDtoDescription.json
@@ -1,3 +1,6 @@
 {
-  "token": "jwt 토큰"
+  "token": "jwt 토큰",
+  "accountNumber": "계좌번호",
+  "isMockRegistered": "모의투자 키 정보 등록 여부",
+  "isRealRegistered": "실전투자 키 정보 등록 여부"
 }

--- a/src/test/resources/json/auth/validate-token/responseDto.json
+++ b/src/test/resources/json/auth/validate-token/responseDto.json
@@ -1,3 +1,6 @@
 {
-  "token": "897851"
+  "token": "897851",
+  "accountNumber": "12345678",
+  "isMockRegistered": true,
+  "isRealRegistered": true
 }

--- a/src/test/resources/json/auth/validate-token/responseDtoDescription.json
+++ b/src/test/resources/json/auth/validate-token/responseDtoDescription.json
@@ -1,3 +1,6 @@
 {
-  "token": "새로운 토큰"
+  "token": "새로운 토큰",
+  "accountNumber": "계좌번호",
+  "isMockRegistered": "모의투자 키 정보 등록 여부",
+  "isRealRegistered": "실전투자 키 정보 등록 여부"
 }

--- a/src/test/resources/json/setting/userInfo.json
+++ b/src/test/resources/json/setting/userInfo.json
@@ -1,0 +1,7 @@
+{
+  "email": "test@naver.com",
+  "password": "1111",
+  "accountNumber": "12345678",
+  "appKey": "test appKey",
+  "appSecret": "test appSecret"
+}


### PR DESCRIPTION
## **PR**

### 작업 내용

- 로그인 및 토큰 검증 API 성공 시 토큰과 계좌번호, 모의-실전 키 등록 여부를 같이 알려줌
- 위 기능을 위한 R2DBC 함수 추가
- dto 네이밍 수정
- 테스트 수정

---
### 참고 사항

R2DBC의 경우 sql 쿼리에 alias가 있으면,
원하는 객체의 필드명과 같아도 정상적으로 매핑되지 않는 버그가 있습니다.
https://github.com/spring-projects/spring-data-relational/issues/1757

때문에 sql에서 바로 등록 여부를 검증하는 것이 아닌,
해당 컬럼의 데이터를 가져온 후
애플리케이션 단에서 검증하도록 구현했습니다.

---
### ✏ Git Close
#185 
